### PR TITLE
Delete wrong author entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "evaluation",
     "typescript"
   ],
-  "author": "FOLIO Technical Council",
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",


### PR DESCRIPTION
https://docs.npmjs.com/cli/v11/configuring-npm/package-json#people-fields-author-contributors

> The "author" is one person.

As TC is not a person TC cannot be listed as "author".