### PR TITLE
Rename to createNotImplementedResult, report manual review

### DIFF
--- a/src/evaluators/base/section-evaluator.ts
+++ b/src/evaluators/base/section-evaluator.ts
@@ -120,17 +120,17 @@ export abstract class BaseSectionEvaluator implements SectionEvaluator {
   }
 
   /**
-   * Create a not applicable result for criteria with stub implementations
+   * Create a manual review result for a criterion with stub implementation
    * @param criterionId The ID of the criterion
    * @param description Brief description of what the criterion evaluates
-   * @returns CriterionResult The not applicable result
+   * @returns CriterionResult The manual review result
    */
-  protected createNotApplicableResult(criterionId: string, description: string): CriterionResult {
+  protected createNotImplementedResult(criterionId: string, description: string): CriterionResult {
     return this.createResult(
       criterionId,
-      EvaluationStatus.NOT_APPLICABLE,
+      EvaluationStatus.MANUAL,
       `${description} - evaluation logic not yet implemented`,
-      'This criterion has a stub implementation. Automated evaluation logic needs to be developed.'
+      'This criterion requires manual evaluation by a human reviewer'
     );
   }
 }

--- a/src/evaluators/java/backend-evaluator.ts
+++ b/src/evaluators/java/backend-evaluator.ts
@@ -53,66 +53,66 @@ export class BackendEvaluator extends BaseSectionEvaluator {
   // Future implementation will analyze code, APIs, and configurations to determine PASS/FAIL status
 
   private async evaluateB001(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('B001', 'API design and RESTful principles');
+    return this.createNotImplementedResult('B001', 'API design and RESTful principles');
   }
 
   private async evaluateB002(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('B002', 'Database design and schema management');
+    return this.createNotImplementedResult('B002', 'Database design and schema management');
   }
 
   private async evaluateB003(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('B003', 'Error handling and validation');
+    return this.createNotImplementedResult('B003', 'Error handling and validation');
   }
 
   private async evaluateB004(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('B004', 'Authentication and authorization');
+    return this.createNotImplementedResult('B004', 'Authentication and authorization');
   }
 
   private async evaluateB005(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('B005', 'Data persistence and transactions');
+    return this.createNotImplementedResult('B005', 'Data persistence and transactions');
   }
 
   private async evaluateB006(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('B006', 'Caching strategy');
+    return this.createNotImplementedResult('B006', 'Caching strategy');
   }
 
   private async evaluateB007(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('B007', 'Event-driven architecture');
+    return this.createNotImplementedResult('B007', 'Event-driven architecture');
   }
 
   private async evaluateB008(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('B008', 'Microservice architecture compliance');
+    return this.createNotImplementedResult('B008', 'Microservice architecture compliance');
   }
 
   private async evaluateB009(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('B009', 'Health checks and monitoring endpoints');
+    return this.createNotImplementedResult('B009', 'Health checks and monitoring endpoints');
   }
 
   private async evaluateB010(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('B010', 'Scalability and load handling');
+    return this.createNotImplementedResult('B010', 'Scalability and load handling');
   }
 
   private async evaluateB011(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('B011', 'Data migration and backward compatibility');
+    return this.createNotImplementedResult('B011', 'Data migration and backward compatibility');
   }
 
   private async evaluateB012(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('B012', 'Environment configuration');
+    return this.createNotImplementedResult('B012', 'Environment configuration');
   }
 
   private async evaluateB013(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('B013', 'Dependency injection and IoC');
+    return this.createNotImplementedResult('B013', 'Dependency injection and IoC');
   }
 
   private async evaluateB014(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('B014', 'API versioning strategy');
+    return this.createNotImplementedResult('B014', 'API versioning strategy');
   }
 
   private async evaluateB015(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('B015', 'Resource management');
+    return this.createNotImplementedResult('B015', 'Resource management');
   }
 
   private async evaluateB016(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('B016', 'Integration testing');
+    return this.createNotImplementedResult('B016', 'Integration testing');
   }
 }

--- a/src/evaluators/java/java-shared-evaluator.ts
+++ b/src/evaluators/java/java-shared-evaluator.ts
@@ -53,7 +53,7 @@ export class JavaSharedEvaluator extends BaseSectionEvaluator {
   }
 
   private async evaluateS002(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S002', 'Module descriptor validation');
+    return this.createNotImplementedResult('S002', 'Module descriptor validation');
   }
 
   private async evaluateS003(repoPath: string): Promise<CriterionResult> {
@@ -61,46 +61,46 @@ export class JavaSharedEvaluator extends BaseSectionEvaluator {
   }
 
   private async evaluateS004(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S004', 'README file evaluation');
+    return this.createNotImplementedResult('S004', 'README file evaluation');
   }
 
   private async evaluateS005(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S005', 'Version control and branching strategy');
+    return this.createNotImplementedResult('S005', 'Version control and branching strategy');
   }
 
   private async evaluateS006(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S006', 'Code quality and static analysis');
+    return this.createNotImplementedResult('S006', 'Code quality and static analysis');
   }
 
   private async evaluateS007(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S007', 'Testing requirements');
+    return this.createNotImplementedResult('S007', 'Testing requirements');
   }
 
   private async evaluateS008(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S008', 'Documentation requirements');
+    return this.createNotImplementedResult('S008', 'Documentation requirements');
   }
 
   private async evaluateS009(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S009', 'Security requirements');
+    return this.createNotImplementedResult('S009', 'Security requirements');
   }
 
   private async evaluateS010(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S010', 'Performance requirements');
+    return this.createNotImplementedResult('S010', 'Performance requirements');
   }
 
   private async evaluateS011(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S011', 'Accessibility requirements');
+    return this.createNotImplementedResult('S011', 'Accessibility requirements');
   }
 
   private async evaluateS012(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S012', 'Internationalization requirements');
+    return this.createNotImplementedResult('S012', 'Internationalization requirements');
   }
 
   private async evaluateS013(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S013', 'Configuration management');
+    return this.createNotImplementedResult('S013', 'Configuration management');
   }
 
   private async evaluateS014(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S014', 'Monitoring and logging');
+    return this.createNotImplementedResult('S014', 'Monitoring and logging');
   }
 }

--- a/src/evaluators/javascript/frontend-evaluator.ts
+++ b/src/evaluators/javascript/frontend-evaluator.ts
@@ -44,7 +44,7 @@ export class FrontendEvaluator extends BaseSectionEvaluator {
    * Check if package.json properly declares stripes dependencies and interfaces
    */
   private async evaluateF001(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult(
+    return this.createNotImplementedResult(
       'F001',
       'API interface requirements in package.json'
     );
@@ -55,7 +55,7 @@ export class FrontendEvaluator extends BaseSectionEvaluator {
    * Check for E2E tests using supported frameworks (e.g., Cypress, BigTest)
    */
   private async evaluateF002(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult(
+    return this.createNotImplementedResult(
       'F002',
       'E2E tests in supported technology (Cypress, BigTest, etc.)'
     );
@@ -66,7 +66,7 @@ export class FrontendEvaluator extends BaseSectionEvaluator {
    * Check if module uses react-intl for internationalization
    */
   private async evaluateF003(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult(
+    return this.createNotImplementedResult(
       'F003',
       'Internationalization support via react-intl'
     );
@@ -77,7 +77,7 @@ export class FrontendEvaluator extends BaseSectionEvaluator {
    * Check for accessibility compliance (automated tests, documentation)
    */
   private async evaluateF004(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult(
+    return this.createNotImplementedResult(
       'F004',
       'WCAG 2.1 AA accessibility compliance'
     );
@@ -88,7 +88,7 @@ export class FrontendEvaluator extends BaseSectionEvaluator {
    * Check if module uses officially supported Stripes version
    */
   private async evaluateF005(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult(
+    return this.createNotImplementedResult(
       'F005',
       'Use of specified Stripes framework version'
     );
@@ -99,7 +99,7 @@ export class FrontendEvaluator extends BaseSectionEvaluator {
    * Check if module follows FOLIO UI conventions and patterns
    */
   private async evaluateF006(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult(
+    return this.createNotImplementedResult(
       'F006',
       'Adherence to existing FOLIO UI layouts and patterns'
     );
@@ -110,7 +110,7 @@ export class FrontendEvaluator extends BaseSectionEvaluator {
    * Check browser compatibility documentation and testing
    */
   private async evaluateF007(repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult(
+    return this.createNotImplementedResult(
       'F007',
       'Browser compatibility with latest Chrome'
     );

--- a/src/evaluators/javascript/javascript-shared-evaluator.ts
+++ b/src/evaluators/javascript/javascript-shared-evaluator.ts
@@ -63,7 +63,7 @@ export class JavaScriptSharedEvaluator extends BaseSectionEvaluator {
    * TODO: Implement package.json stripes metadata validation
    */
   private async evaluateS002(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S002', 'package.json and stripes metadata validation');
+    return this.createNotImplementedResult('S002', 'package.json and stripes metadata validation');
   }
 
   /**
@@ -76,15 +76,15 @@ export class JavaScriptSharedEvaluator extends BaseSectionEvaluator {
   }
 
   private async evaluateS004(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S004', 'README file evaluation');
+    return this.createNotImplementedResult('S004', 'README file evaluation');
   }
 
   private async evaluateS005(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S005', 'Version control and branching strategy');
+    return this.createNotImplementedResult('S005', 'Version control and branching strategy');
   }
 
   private async evaluateS006(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S006', 'Code quality and static analysis');
+    return this.createNotImplementedResult('S006', 'Code quality and static analysis');
   }
 
   /**
@@ -93,7 +93,7 @@ export class JavaScriptSharedEvaluator extends BaseSectionEvaluator {
    * TODO: Implement package.json technology version checks
    */
   private async evaluateS007(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S007', 'Supported technologies (React, Node.js, Stripes)');
+    return this.createNotImplementedResult('S007', 'Supported technologies (React, Node.js, Stripes)');
   }
 
   /**
@@ -102,7 +102,7 @@ export class JavaScriptSharedEvaluator extends BaseSectionEvaluator {
    * TODO: Implement Stripes interface usage validation
    */
   private async evaluateS008(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S008', 'FOLIO Stripes interface usage');
+    return this.createNotImplementedResult('S008', 'FOLIO Stripes interface usage');
   }
 
   /**
@@ -111,11 +111,11 @@ export class JavaScriptSharedEvaluator extends BaseSectionEvaluator {
    * TODO: Implement npm package approval checking
    */
   private async evaluateS009(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S009', 'Approved npm package dependencies');
+    return this.createNotImplementedResult('S009', 'Approved npm package dependencies');
   }
 
   private async evaluateS010(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S010', 'Performance requirements');
+    return this.createNotImplementedResult('S010', 'Performance requirements');
   }
 
   /**
@@ -124,7 +124,7 @@ export class JavaScriptSharedEvaluator extends BaseSectionEvaluator {
    * TODO: Implement sonar configuration validation
    */
   private async evaluateS011(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S011', 'Sonarqube security configuration');
+    return this.createNotImplementedResult('S011', 'Sonarqube security configuration');
   }
 
   /**
@@ -133,7 +133,7 @@ export class JavaScriptSharedEvaluator extends BaseSectionEvaluator {
    * TODO: Implement npm/yarn validation
    */
   private async evaluateS012(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S012', 'Build tools (npm/yarn)');
+    return this.createNotImplementedResult('S012', 'Build tools (npm/yarn)');
   }
 
   /**
@@ -142,10 +142,10 @@ export class JavaScriptSharedEvaluator extends BaseSectionEvaluator {
    * TODO: Implement JavaScript test coverage extraction
    */
   private async evaluateS013(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S013', 'Unit test coverage (Jest/Istanbul)');
+    return this.createNotImplementedResult('S013', 'Unit test coverage (Jest/Istanbul)');
   }
 
   private async evaluateS014(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotApplicableResult('S014', 'Application descriptor assignment');
+    return this.createNotImplementedResult('S014', 'Application descriptor assignment');
   }
 }


### PR DESCRIPTION
If a criterion lacks an implementation for automated review it currently reports "not_applicable".

This is wrong.

Such a criterion requires manual review.

Therefore
* change the result from not_applicable to manual
* rename the method from createNotApplicableResult to createNotImplementedResult