### PR TITLE
Fix yarn install failure for npm dependency extraction

### DIFF
--- a/.github/workflows/evaluate-remote.yml
+++ b/.github/workflows/evaluate-remote.yml
@@ -36,7 +36,7 @@ on:
         description: "Node.js version"
         required: false
         type: string
-        default: "18"
+        default: "20"
 
 permissions:
   contents: read

--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -32,7 +32,7 @@ on:
         description: "Node.js version to use"
         required: false
         type: string
-        default: "18"
+        default: "20"
       evaluator_ref:
         description: "tc-module-eval ref (branch/tag) to use"
         required: false

--- a/src/utils/parsers/npm-dependency-parser.ts
+++ b/src/utils/parsers/npm-dependency-parser.ts
@@ -286,8 +286,11 @@ export async function getNpmDependencies(repoPath: string): Promise<DependencyEx
 
     // Step 1: Run yarn install to get all dependencies including transitives
     // SECURITY: --ignore-scripts prevents execution of preinstall/postinstall/etc scripts
+    // --ignore-engines bypasses Node.js engine compatibility checks that can cause
+    // failures when transitive dependencies require newer Node versions (e.g., @formatjs/cli
+    // requiring Node >= 20). Engine compat is irrelevant for license extraction.
     getLogger().info('Running yarn install...');
-    await execAsync('yarn install --production --ignore-scripts', {
+    await execAsync('yarn install --production --ignore-scripts --ignore-engines', {
       cwd: validatedPath,
       timeout: INSTALL_TIMEOUT
     });


### PR DESCRIPTION
## Purpose

Fixes npm dependency extraction failing for FOLIO UI modules like `ui-inventory-import` when transitive dependencies require Node >= 20. The `yarn install` engine check failure causes a fallback to `package.json` parsing, producing incomplete results — only direct deps, no license info, and version specs instead of resolved versions.

Closes #23

## Approach

- Add `--ignore-engines` flag to `yarn install` in the npm dependency parser. Engine compatibility is irrelevant for license extraction.
- Bump default `node_version` from 18 to 20 in both workflow files, since Node 18 is EOL and FOLIO packages increasingly require Node >= 20.

Verified with a [successful run](https://github.com/folio-org/tc-module-eval/actions/runs/22862503728) against `ui-inventory-import` from this branch.