### PR TITLE
Repoint criteria source comment to master

### DIFF
--- a/src/criteria-definitions.ts
+++ b/src/criteria-definitions.ts
@@ -2,7 +2,7 @@
  * Centralized definitions of all FOLIO technical council acceptance criteria
  * This file serves as the single source of truth for all criterion IDs and their organization
  *
- * Source: https://raw.githubusercontent.com/folio-org/tech-council/refs/heads/criteria-ids/MODULE_ACCEPTANCE_CRITERIA.MD
+ * Source: https://raw.githubusercontent.com/folio-org/tech-council/refs/heads/master/MODULE_ACCEPTANCE_CRITERIA.MD
  */
 
 /**


### PR DESCRIPTION
## What
Updates the `Source:` reference in `src/criteria-definitions.ts` to point at the canonical `master` branch of `folio-org/tech-council` instead of `refs/heads/criteria-ids`.

## Why
`criteria-definitions.ts` is the tool's single source of truth for criterion IDs, but its provenance comment points at the `criteria-ids` branch, which was a draft and **no longer exists** — a dangling reference. `master` is the correct canonical location.

## Note on ordering
The criterion IDs themselves are being (re)introduced to `tech-council/master` via a separate PR. Until that merges, `master` will not yet contain the inline IDs. This change is comment-only and does not affect runtime behavior; it can merge independently, but the referenced URL only becomes fully accurate once the tech-council PR lands.