### PR TITLE
refactor: deepen evaluation architecture

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -68,10 +68,5 @@
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
   "postCreateCommand": "yarn install && mkdir -p /home/node/.m2 && cp /workspace/.devcontainer/maven-settings.xml /home/node/.m2/settings.xml",
-  "postStartCommand": "mkdir -p /home/node/.m2/repository",
-  "features": {
-    "ghcr.io/devcontainers/features/git:1": {
-      "version": "latest"
-    }
-  }
+  "postStartCommand": "mkdir -p /home/node/.m2/repository"
 }

--- a/src/__tests__/criteria-definitions.test.ts
+++ b/src/__tests__/criteria-definitions.test.ts
@@ -7,8 +7,12 @@ import {
   isValidCriterionId,
   getSectionForCriterion,
   getDescriptionForCriterion,
-  getCriterionDefinition
+  getCriterionDefinition,
+  getAcceptanceCriterionDefinition,
+  getCriteriaForSection,
+  createDefaultCriterionResult
 } from '../criteria-definitions';
+import { EvaluationStatus } from '../types';
 
 describe('criteria-definitions', () => {
   describe('getCriteriaForLanguage', () => {
@@ -161,6 +165,60 @@ describe('criteria-definitions', () => {
 
     it('should return undefined for invalid criterion', () => {
       expect(getCriterionDefinition('X001')).toBeUndefined();
+    });
+  });
+
+  describe('acceptance criterion catalog', () => {
+    it('should expose canonical criteria by section and language', () => {
+      expect(getCriteriaForSection('Shared/Common', 'java')).toEqual(SHARED_CRITERIA);
+      expect(getCriteriaForSection('Shared/Common', 'javascript')).toEqual(SHARED_CRITERIA);
+      expect(getCriteriaForSection('Backend', 'java')).toEqual([
+        'B001', 'B002', 'B003', 'B004', 'B005', 'B006', 'B007', 'B008',
+        'B009', 'B010', 'B011', 'B012', 'B013', 'B014', 'B015', 'B016'
+      ]);
+      expect(getCriteriaForSection('Frontend', 'javascript')).toEqual(FRONTEND_CRITERIA);
+      expect(getCriteriaForSection('Frontend', 'java')).toEqual([]);
+    });
+
+    it('should expose extended catalog metadata without changing basic definitions', () => {
+      const catalogEntry = getAcceptanceCriterionDefinition('S002');
+      expect(catalogEntry?.languages).toEqual(['java', 'javascript']);
+      expect(catalogEntry?.defaultEvaluation?.reason).toBe('Module descriptor validation');
+
+      expect(getCriterionDefinition('S002')).toEqual({
+        id: 'S002',
+        description: 'Module build produces valid module descriptor',
+        section: 'Shared/Common'
+      });
+    });
+
+    it('should create default Java not-implemented results from the catalog', () => {
+      const result = createDefaultCriterionResult('S002', 'java');
+
+      expect(result).toEqual({
+        criterionId: 'S002',
+        status: EvaluationStatus.MANUAL,
+        evidence: 'Module descriptor validation - evaluation logic not yet implemented',
+        details: 'This criterion requires manual evaluation by a human reviewer'
+      });
+    });
+
+    it('should create manual-review fallback results from the catalog', () => {
+      const result = createDefaultCriterionResult('A001', 'java');
+
+      expect(result).toEqual({
+        criterionId: 'A001',
+        status: EvaluationStatus.MANUAL,
+        evidence: 'Product Council approval verification requires manual review',
+        details: 'This criterion requires manual evaluation by a human reviewer'
+      });
+    });
+
+    it('should create JavaScript-specific fallback wording from the catalog', () => {
+      const result = createDefaultCriterionResult('S002', 'javascript');
+
+      expect(result.status).toBe(EvaluationStatus.MANUAL);
+      expect(result.evidence).toBe('package.json and stripes metadata validation - evaluation logic not yet implemented');
     });
   });
 });

--- a/src/__tests__/license-compliance-evaluator.test.ts
+++ b/src/__tests__/license-compliance-evaluator.test.ts
@@ -1,5 +1,10 @@
 import { EvaluationStatus, LicenseIssueType, ComplianceResult, DependencyExtractionError, Dependency } from '../types';
-import { formatExtractionErrors, determineComplianceStatus } from '../utils/license-compliance-evaluator';
+import {
+  formatExtractionErrors,
+  determineComplianceStatus,
+  ThirdPartyLicenseEvaluator,
+  ThirdPartyLicenseEvaluatorAdapters
+} from '../utils/license-compliance-evaluator';
 import { setLogger, resetLogger, NoopLogger } from '../utils/logger';
 
 beforeEach(() => {
@@ -171,5 +176,146 @@ describe('determineComplianceStatus', () => {
     const result = determineComplianceStatus('CUSTOM01', complianceResult, evidence, [], false);
 
     expect(result.criterionId).toBe('CUSTOM01');
+  });
+});
+
+describe('ThirdPartyLicenseEvaluator', () => {
+  const dependency: Dependency = {
+    name: 'example-lib',
+    version: '1.0.0',
+    licenses: ['MIT']
+  };
+
+  function createEvaluator(
+    extraction: Awaited<ReturnType<ThirdPartyLicenseEvaluatorAdapters['extractDependencies']>>,
+    complianceResult: ComplianceResult = { compliant: true, issues: [] },
+    readmeContent: string = 'README content'
+  ): ThirdPartyLicenseEvaluator {
+    return new ThirdPartyLicenseEvaluator({
+      extractDependencies: jest.fn().mockResolvedValue(extraction),
+      readReadmeContent: jest.fn().mockReturnValue(readmeContent),
+      checkCompliance: jest.fn().mockReturnValue(complianceResult)
+    });
+  }
+
+  it('should return MANUAL when dependency extraction has errors', async () => {
+    const evaluator = createEvaluator({
+      dependencies: [],
+      errors: [{ source: 'maven-parser', message: 'Build failed' }],
+      warnings: []
+    });
+
+    const result = await evaluator.evaluate('/repo');
+
+    expect(result.status).toBe(EvaluationStatus.MANUAL);
+    expect(result.evidence).toBe('Failed to extract dependencies due to 1 error(s)');
+    expect(result.details).toContain('Dependency extraction errors:');
+    expect(result.details).toContain('[maven-parser] Build failed');
+  });
+
+  it('should return MANUAL when no dependencies are found', async () => {
+    const evaluator = createEvaluator({
+      dependencies: [],
+      errors: [],
+      warnings: [{ source: 'dependency-orchestrator', message: 'No supported build tools found' }]
+    });
+
+    const result = await evaluator.evaluate('/repo');
+
+    expect(result.status).toBe(EvaluationStatus.MANUAL);
+    expect(result.evidence).toBe('No third-party dependencies found');
+    expect(result.details).toContain('Manual review required to confirm compliance');
+    expect(result.details).toContain('[dependency-orchestrator] No supported build tools found');
+  });
+
+  it('should return PASS when dependencies are compliant', async () => {
+    const evaluator = createEvaluator({
+      dependencies: [dependency],
+      errors: [],
+      warnings: []
+    });
+
+    const result = await evaluator.evaluate('/repo');
+
+    expect(result.status).toBe(EvaluationStatus.PASS);
+    expect(result.evidence).toBe('Found 1 dependencies. Licenses: example-lib:1.0.0 (MIT)');
+    expect(result.details).toContain('All third-party dependencies comply');
+  });
+
+  it('should return MANUAL when compliant dependencies came from fallback extraction', async () => {
+    const evaluator = createEvaluator({
+      dependencies: [dependency],
+      errors: [],
+      warnings: [{ source: 'npm-parser', message: 'Fallback mode used - ONLY DIRECT DEPENDENCIES analyzed' }]
+    });
+
+    const result = await evaluator.evaluate('/repo');
+
+    expect(result.status).toBe(EvaluationStatus.MANUAL);
+    expect(result.details).toContain('MANUAL REVIEW REQUIRED');
+    expect(result.details).toContain('Transitive dependencies are unavailable');
+  });
+
+  it('should return FAIL when Category X violations are present', async () => {
+    const evaluator = createEvaluator(
+      {
+        dependencies: [dependency],
+        errors: [],
+        warnings: []
+      },
+      {
+        compliant: false,
+        issues: [{
+          dependency,
+          reason: 'License GPL-3.0 is in Category X (prohibited)',
+          issueType: LicenseIssueType.CATEGORY_X_VIOLATION
+        }]
+      }
+    );
+
+    const result = await evaluator.evaluate('/repo');
+
+    expect(result.status).toBe(EvaluationStatus.FAIL);
+    expect(result.details).toContain('License GPL-3.0 is in Category X');
+  });
+
+  it('should return MANUAL when compliance issues require manual review', async () => {
+    const evaluator = createEvaluator(
+      {
+        dependencies: [dependency],
+        errors: [],
+        warnings: []
+      },
+      {
+        compliant: false,
+        issues: [{
+          dependency,
+          reason: 'Unknown license',
+          issueType: LicenseIssueType.UNKNOWN_LICENSE
+        }]
+      }
+    );
+
+    const result = await evaluator.evaluate('/repo');
+
+    expect(result.status).toBe(EvaluationStatus.MANUAL);
+    expect(result.details).toContain('require manual review');
+  });
+
+  it('should return MANUAL when an adapter throws during evaluation', async () => {
+    const evaluator = new ThirdPartyLicenseEvaluator({
+      extractDependencies: jest.fn().mockRejectedValue(new Error('Dependency tool crashed')),
+      readReadmeContent: jest.fn(),
+      checkCompliance: jest.fn()
+    });
+
+    const result = await evaluator.evaluate('/repo');
+
+    expect(result).toEqual({
+      criterionId: 'S003',
+      status: EvaluationStatus.MANUAL,
+      evidence: 'Error occurred during dependency analysis',
+      details: 'Failed to analyze third-party license compliance: Dependency tool crashed. Manual review required.'
+    });
   });
 });

--- a/src/__tests__/npm-dependency-parser.test.ts
+++ b/src/__tests__/npm-dependency-parser.test.ts
@@ -124,6 +124,11 @@ describe('npm-dependency-parser', () => {
 
       const result = await getNpmDependencies('/test/repo');
 
+      expect(mockExecAsync).toHaveBeenNthCalledWith(
+        1,
+        'yarn install --production --ignore-scripts --ignore-engines',
+        expect.objectContaining({ cwd: '/test/repo' })
+      );
       expect(result.dependencies).toHaveLength(3);
 
       const express = result.dependencies.find(d => d.name === 'express');

--- a/src/__tests__/report-generator.test.ts
+++ b/src/__tests__/report-generator.test.ts
@@ -1,0 +1,71 @@
+import * as fs from 'fs-extra';
+import { ReportGenerator } from '../utils/report-generator';
+import { ReportRenderer } from '../utils/report-renderer';
+import { EvaluationResult } from '../types';
+import { setLogger, resetLogger, NoopLogger } from '../utils/logger';
+
+jest.mock('fs-extra', () => ({
+  ensureDir: jest.fn(),
+  writeFile: jest.fn()
+}));
+
+describe('ReportGenerator', () => {
+  const result: EvaluationResult = {
+    repositoryUrl: 'https://github.com/folio-org/test-module',
+    moduleName: 'test-module',
+    language: 'Java',
+    evaluatedAt: new Date('2026-06-03T12:00:00.000Z'),
+    criteria: []
+  };
+
+  const mockFs = fs as jest.Mocked<typeof fs>;
+
+  beforeEach(() => {
+    setLogger(new NoopLogger());
+    jest.clearAllMocks();
+    (mockFs.ensureDir as jest.Mock).mockResolvedValue(undefined);
+    (mockFs.writeFile as unknown as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    resetLogger();
+  });
+
+  it('should write both report formats by default', async () => {
+    const renderer: jest.Mocked<ReportRenderer> = {
+      renderJson: jest.fn().mockReturnValue('json report'),
+      renderHtml: jest.fn().mockReturnValue('html report')
+    };
+    const generator = new ReportGenerator('/tmp/reports', renderer);
+
+    const paths = await generator.generateReports(result);
+
+    expect(mockFs.ensureDir).toHaveBeenCalledWith('/tmp/reports');
+    expect(paths.jsonPath).toMatch(/\/tmp\/reports\/test-module-.+\.json$/);
+    expect(paths.htmlPath).toMatch(/\/tmp\/reports\/test-module-.+\.html$/);
+    expect(mockFs.writeFile).toHaveBeenCalledTimes(2);
+    expect(renderer.renderJson).toHaveBeenCalledWith(result);
+    expect(renderer.renderHtml).toHaveBeenCalledWith(result);
+  });
+
+  it('should respect report format options', async () => {
+    const renderer: jest.Mocked<ReportRenderer> = {
+      renderJson: jest.fn().mockReturnValue('json report'),
+      renderHtml: jest.fn().mockReturnValue('html report')
+    };
+    const generator = new ReportGenerator('/tmp/reports', renderer);
+
+    const paths = await generator.generateReports(result, {
+      outputJson: true,
+      outputHtml: false,
+      outputDir: '/tmp/custom-reports'
+    });
+
+    expect(mockFs.ensureDir).toHaveBeenCalledWith('/tmp/custom-reports');
+    expect(paths.jsonPath).toMatch(/\/tmp\/custom-reports\/test-module-.+\.json$/);
+    expect(paths.htmlPath).toBeUndefined();
+    expect(mockFs.writeFile).toHaveBeenCalledTimes(1);
+    expect(renderer.renderJson).toHaveBeenCalledWith(result);
+    expect(renderer.renderHtml).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/report-renderer.test.ts
+++ b/src/__tests__/report-renderer.test.ts
@@ -1,0 +1,72 @@
+import { EvaluationReportRenderer } from '../utils/report-renderer';
+import { EvaluationResult, EvaluationStatus } from '../types';
+
+describe('EvaluationReportRenderer', () => {
+  const result: EvaluationResult = {
+    repositoryUrl: 'https://github.com/folio-org/test-module',
+    moduleName: 'test-module',
+    language: 'Java',
+    evaluatedAt: new Date('2026-06-03T12:00:00.000Z'),
+    criteria: [
+      {
+        criterionId: 'S001',
+        status: EvaluationStatus.PASS,
+        evidence: 'Apache <2.0> & compatible',
+        details: 'Line one\nLine two'
+      },
+      {
+        criterionId: 'S002',
+        status: EvaluationStatus.FAIL,
+        evidence: 'Failed evidence'
+      },
+      {
+        criterionId: 'S003',
+        status: EvaluationStatus.MANUAL,
+        evidence: 'Manual evidence'
+      },
+      {
+        criterionId: 'S004',
+        status: EvaluationStatus.NOT_APPLICABLE,
+        evidence: 'Not applicable evidence'
+      }
+    ]
+  };
+
+  it('should calculate report stats', () => {
+    const renderer = new EvaluationReportRenderer();
+
+    expect(renderer.calculateStats(result)).toEqual({
+      pass: 1,
+      fail: 1,
+      manual: 1,
+      notApplicable: 1,
+      total: 4
+    });
+  });
+
+  it('should render JSON with stable indentation', () => {
+    const renderer = new EvaluationReportRenderer();
+    const json = renderer.renderJson(result);
+
+    expect(json).toContain('\n  "moduleName": "test-module"');
+    expect(JSON.parse(json).criteria).toHaveLength(4);
+  });
+
+  it('should escape HTML and preserve multiline details', () => {
+    const renderer = new EvaluationReportRenderer();
+    const html = renderer.renderHtml(result);
+
+    expect(html).toContain('FOLIO Module Evaluation Report');
+    expect(html).toContain('test-module');
+    expect(html).toContain('Criterion S001');
+    expect(html).toContain('Apache &lt;2.0&gt; &amp; compatible');
+    expect(html).toContain('Line one<br>Line two');
+  });
+
+  it('should expose escaping helpers for focused renderer tests', () => {
+    const renderer = new EvaluationReportRenderer();
+
+    expect(renderer.escapeHtml(`<&>"'`)).toBe('&lt;&amp;&gt;&quot;&#39;');
+    expect(renderer.textToHtml('one\ntwo')).toBe('one<br>two');
+  });
+});

--- a/src/__tests__/shared-abstractions.test.ts
+++ b/src/__tests__/shared-abstractions.test.ts
@@ -1,7 +1,9 @@
 import { CriterionResult, EvaluationStatus, SectionEvaluator, CriterionFunction } from '../types';
 import { SharedEvaluator } from '../evaluators/shared/shared-evaluator';
+import { JavaScriptSharedEvaluator } from '../evaluators/javascript/javascript-shared-evaluator';
 import { CompositeLanguageEvaluator } from '../evaluators/base/composite-language-evaluator';
 import { BaseSectionEvaluator } from '../evaluators/base/section-evaluator';
+import { CatalogSectionEvaluator } from '../evaluators/base/catalog-section-evaluator';
 import { setLogger, resetLogger, NoopLogger } from '../utils/logger';
 
 // Mock fs-extra (needed by SharedEvaluator -> LicenseUtils)
@@ -98,6 +100,15 @@ describe('SharedEvaluator', () => {
     expect(result.status).toBe(EvaluationStatus.PASS);
     expect(result.evidence).toBe('Custom override works');
   });
+
+  it('should use catalog-backed JavaScript fallback wording', async () => {
+    const evaluator = new JavaScriptSharedEvaluator();
+    const result = await evaluator.evaluateCriterion('S002', '/fake/path');
+
+    expect(result.criterionId).toBe('S002');
+    expect(result.status).toBe(EvaluationStatus.MANUAL);
+    expect(result.evidence).toBe('package.json and stripes metadata validation - evaluation logic not yet implemented');
+  });
 });
 
 describe('BaseSectionEvaluator', () => {
@@ -159,6 +170,20 @@ describe('BaseSectionEvaluator', () => {
     expect(results[1].evidence).toContain('Handler exploded');
     // Evaluation continues after the error
     expect(results[2].status).toBe(EvaluationStatus.PASS);
+  });
+});
+
+describe('CatalogSectionEvaluator', () => {
+  it('should fail fast when a catalog criterion has neither fallback nor override', () => {
+    class MissingOverrideEvaluator extends CatalogSectionEvaluator {
+      constructor() {
+        super('Shared/Common', 'java');
+      }
+    }
+
+    expect(() => new MissingOverrideEvaluator()).toThrow(
+      'No default evaluation or handler registered for criterion: S001'
+    );
   });
 });
 

--- a/src/criteria-definitions.ts
+++ b/src/criteria-definitions.ts
@@ -5,6 +5,8 @@
  * Source: https://raw.githubusercontent.com/folio-org/tech-council/refs/heads/criteria-ids/MODULE_ACCEPTANCE_CRITERIA.MD
  */
 
+import { CriterionResult, EvaluationStatus } from './types';
+
 /**
  * Individual criterion definition
  */
@@ -14,265 +16,545 @@ export interface CriterionDefinition {
   section: string;
 }
 
+export type CriterionSection = 'Administrative' | 'Shared/Common' | 'Backend' | 'Frontend';
+export type CriterionLanguage = 'java' | 'javascript';
+
+export interface CriterionDefaultEvaluation {
+  type: 'manual_review' | 'not_implemented';
+  reason: string;
+  languageReasons?: Partial<Record<CriterionLanguage, string>>;
+}
+
+export interface AcceptanceCriterionDefinition extends CriterionDefinition {
+  section: CriterionSection;
+  languages: readonly CriterionLanguage[];
+  defaultEvaluation?: CriterionDefaultEvaluation;
+}
+
+const HUMAN_REVIEW_DETAILS = 'This criterion requires manual evaluation by a human reviewer';
+
+/**
+ * Complete catalog of all FOLIO technical council acceptance criteria.
+ * The catalog owns canonical order, applicability, and fallback evaluation text.
+ */
+export const ACCEPTANCE_CRITERION_CATALOG = [
+  {
+    id: 'A001',
+    description: 'Listed by Product Council with positive evaluation result',
+    section: 'Administrative',
+    languages: ['java', 'javascript'],
+    defaultEvaluation: {
+      type: 'manual_review',
+      reason: 'Product Council approval verification requires manual review'
+    }
+  },
+
+  {
+    id: 'S001',
+    description: 'Uses Apache 2.0 license',
+    section: 'Shared/Common',
+    languages: ['java', 'javascript']
+  },
+  {
+    id: 'S002',
+    description: 'Module build produces valid module descriptor',
+    section: 'Shared/Common',
+    languages: ['java', 'javascript'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Module descriptor validation',
+      languageReasons: {
+        javascript: 'package.json and stripes metadata validation'
+      }
+    }
+  },
+  {
+    id: 'S003',
+    description: 'Third-party dependencies comply with ASF license policy',
+    section: 'Shared/Common',
+    languages: ['java', 'javascript']
+  },
+  {
+    id: 'S004',
+    description: 'Installation documentation included',
+    section: 'Shared/Common',
+    languages: ['java', 'javascript'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'README file evaluation'
+    }
+  },
+  {
+    id: 'S005',
+    description: 'Personal data form completed',
+    section: 'Shared/Common',
+    languages: ['java', 'javascript'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Version control and branching strategy'
+    }
+  },
+  {
+    id: 'S006',
+    description: 'No sensitive info in git repository',
+    section: 'Shared/Common',
+    languages: ['java', 'javascript'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Code quality and static analysis'
+    }
+  },
+  {
+    id: 'S007',
+    description: 'Written in officially supported technologies',
+    section: 'Shared/Common',
+    languages: ['java', 'javascript'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Testing requirements',
+      languageReasons: {
+        javascript: 'Supported technologies (React, Node.js, Stripes)'
+      }
+    }
+  },
+  {
+    id: 'S008',
+    description: 'Uses existing FOLIO interfaces',
+    section: 'Shared/Common',
+    languages: ['java', 'javascript'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Documentation requirements',
+      languageReasons: {
+        javascript: 'FOLIO Stripes interface usage'
+      }
+    }
+  },
+  {
+    id: 'S009',
+    description: 'No unapproved FOLIO library dependencies',
+    section: 'Shared/Common',
+    languages: ['java', 'javascript'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Security requirements',
+      languageReasons: {
+        javascript: 'Approved npm package dependencies'
+      }
+    }
+  },
+  {
+    id: 'S010',
+    description: 'Handles absence of third-party systems',
+    section: 'Shared/Common',
+    languages: ['java', 'javascript'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Performance requirements'
+    }
+  },
+  {
+    id: 'S011',
+    description: 'Passes Sonarqube security checks',
+    section: 'Shared/Common',
+    languages: ['java', 'javascript'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Accessibility requirements',
+      languageReasons: {
+        javascript: 'Sonarqube security configuration'
+      }
+    }
+  },
+  {
+    id: 'S012',
+    description: 'Uses officially supported build tools',
+    section: 'Shared/Common',
+    languages: ['java', 'javascript'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Internationalization requirements',
+      languageReasons: {
+        javascript: 'Build tools (npm/yarn)'
+      }
+    }
+  },
+  {
+    id: 'S013',
+    description: '80%+ unit test coverage',
+    section: 'Shared/Common',
+    languages: ['java', 'javascript'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Configuration management',
+      languageReasons: {
+        javascript: 'Unit test coverage (Jest/Istanbul)'
+      }
+    }
+  },
+  {
+    id: 'S014',
+    description: 'Assigned to one application descriptor',
+    section: 'Shared/Common',
+    languages: ['java', 'javascript'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Monitoring and logging'
+    }
+  },
+
+  {
+    id: 'B001',
+    description: 'Compliant Module Descriptor',
+    section: 'Backend',
+    languages: ['java'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'API design and RESTful principles'
+    }
+  },
+  {
+    id: 'B002',
+    description: 'API interface requirements in module descriptor',
+    section: 'Backend',
+    languages: ['java'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Database design and schema management'
+    }
+  },
+  {
+    id: 'B003',
+    description: 'Implement all endpoints in Module Descriptor',
+    section: 'Backend',
+    languages: ['java'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Error handling and validation'
+    }
+  },
+  {
+    id: 'B004',
+    description: 'Environment vars documented',
+    section: 'Backend',
+    languages: ['java'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Authentication and authorization'
+    }
+  },
+  {
+    id: 'B005',
+    description: 'Provide interfaces per naming conventions',
+    section: 'Backend',
+    languages: ['java'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Data persistence and transactions'
+    }
+  },
+  {
+    id: 'B006',
+    description: 'OpenAPI documentation for endpoints',
+    section: 'Backend',
+    languages: ['java'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Caching strategy'
+    }
+  },
+  {
+    id: 'B007',
+    description: 'Appropriate endpoint permissions',
+    section: 'Backend',
+    languages: ['java'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Event-driven architecture'
+    }
+  },
+  {
+    id: 'B008',
+    description: 'Provide reference data',
+    section: 'Backend',
+    languages: ['java'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Microservice architecture compliance'
+    }
+  },
+  {
+    id: 'B009',
+    description: 'Integration tests in supported technology',
+    section: 'Backend',
+    languages: ['java'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Health checks and monitoring endpoints'
+    }
+  },
+  {
+    id: 'B010',
+    description: 'Tenant data segregation',
+    section: 'Backend',
+    languages: ['java'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Scalability and load handling'
+    }
+  },
+  {
+    id: 'B011',
+    description: 'Restricted database schema access',
+    section: 'Backend',
+    languages: ['java'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Data migration and backward compatibility'
+    }
+  },
+  {
+    id: 'B012',
+    description: 'Dependencies declared in README',
+    section: 'Backend',
+    languages: ['java'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Environment configuration'
+    }
+  },
+  {
+    id: 'B013',
+    description: 'Respond with tenant-specific content',
+    section: 'Backend',
+    languages: ['java'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Dependency injection and IoC'
+    }
+  },
+  {
+    id: 'B014',
+    description: 'Standard health check endpoint',
+    section: 'Backend',
+    languages: ['java'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'API versioning strategy'
+    }
+  },
+  {
+    id: 'B015',
+    description: 'High Availability compliance',
+    section: 'Backend',
+    languages: ['java'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Resource management'
+    }
+  },
+  {
+    id: 'B016',
+    description: 'Use only supported infrastructure technologies',
+    section: 'Backend',
+    languages: ['java'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Integration testing'
+    }
+  },
+
+  {
+    id: 'F001',
+    description: 'API interface requirements in package.json',
+    section: 'Frontend',
+    languages: ['javascript'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'API interface requirements in package.json'
+    }
+  },
+  {
+    id: 'F002',
+    description: 'E2E tests in supported technology',
+    section: 'Frontend',
+    languages: ['javascript'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'E2E tests in supported technology (Cypress, BigTest, etc.)'
+    }
+  },
+  {
+    id: 'F003',
+    description: 'i18n support via react-intl',
+    section: 'Frontend',
+    languages: ['javascript'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Internationalization support via react-intl'
+    }
+  },
+  {
+    id: 'F004',
+    description: 'WCAG 2.1 AA compliance',
+    section: 'Frontend',
+    languages: ['javascript'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'WCAG 2.1 AA accessibility compliance'
+    }
+  },
+  {
+    id: 'F005',
+    description: 'Use specified Stripes version',
+    section: 'Frontend',
+    languages: ['javascript'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Use of specified Stripes framework version'
+    }
+  },
+  {
+    id: 'F006',
+    description: 'Follow existing UI layouts/patterns',
+    section: 'Frontend',
+    languages: ['javascript'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Adherence to existing FOLIO UI layouts and patterns'
+    }
+  },
+  {
+    id: 'F007',
+    description: 'Works in latest Chrome',
+    section: 'Frontend',
+    languages: ['javascript'],
+    defaultEvaluation: {
+      type: 'not_implemented',
+      reason: 'Browser compatibility with latest Chrome'
+    }
+  }
+] as const satisfies readonly AcceptanceCriterionDefinition[];
+
+export type AcceptanceCriterion = AcceptanceCriterionDefinition;
+type CatalogCriterion = typeof ACCEPTANCE_CRITERION_CATALOG[number];
+export type CriterionId = CatalogCriterion['id'];
+export type AdministrativeCriterionId = Extract<CatalogCriterion, { section: 'Administrative' }>['id'];
+export type SharedCriterionId = Extract<CatalogCriterion, { section: 'Shared/Common' }>['id'];
+export type BackendCriterionId = Extract<CatalogCriterion, { section: 'Backend' }>['id'];
+export type FrontendCriterionId = Extract<CatalogCriterion, { section: 'Frontend' }>['id'];
+export type JavaCriterionId = AdministrativeCriterionId | SharedCriterionId | BackendCriterionId;
+
+type CriteriaIdsForSection<
+  Catalog extends readonly { id: string; section: CriterionSection }[],
+  Section extends CriterionSection,
+  Result extends readonly string[] = readonly []
+> = Catalog extends readonly [infer Head, ...infer Tail]
+  ? Head extends { id: string; section: CriterionSection }
+    ? Tail extends readonly { id: string; section: CriterionSection }[]
+      ? Head['section'] extends Section
+        ? CriteriaIdsForSection<Tail, Section, readonly [...Result, Head['id']]>
+        : CriteriaIdsForSection<Tail, Section, Result>
+      : Result
+    : Result
+  : Result;
+
+type CriteriaIdsForLanguage<
+  Catalog extends readonly { id: string; languages: readonly CriterionLanguage[] }[],
+  Language extends CriterionLanguage,
+  Result extends readonly string[] = readonly []
+> = Catalog extends readonly [infer Head, ...infer Tail]
+  ? Head extends { id: string; languages: readonly CriterionLanguage[] }
+    ? Tail extends readonly { id: string; languages: readonly CriterionLanguage[] }[]
+      ? Language extends Head['languages'][number]
+        ? CriteriaIdsForLanguage<Tail, Language, readonly [...Result, Head['id']]>
+        : CriteriaIdsForLanguage<Tail, Language, Result>
+      : Result
+    : Result
+  : Result;
+
+type CriteriaIdsForCatalog<
+  Catalog extends readonly { id: string }[],
+  Result extends readonly string[] = readonly []
+> = Catalog extends readonly [infer Head, ...infer Tail]
+  ? Head extends { id: string }
+    ? Tail extends readonly { id: string }[]
+      ? CriteriaIdsForCatalog<Tail, readonly [...Result, Head['id']]>
+      : Result
+    : Result
+  : Result;
+
+type JavaCriteria = CriteriaIdsForLanguage<typeof ACCEPTANCE_CRITERION_CATALOG, 'java'>;
+type AllCriteria = CriteriaIdsForCatalog<typeof ACCEPTANCE_CRITERION_CATALOG>;
+
+/**
+ * Build the canonical, ordered list of criterion IDs for a section.
+ *
+ * The return TYPE is derived from the catalog via {@link CriteriaIdsForSection},
+ * so it can never silently drift from the data. The single assertion only bridges
+ * the runtime `filter`/`map` result (which TypeScript widens to `string[]`) to that
+ * catalog-derived tuple type — both sides apply the same `section` predicate to the
+ * same catalog, so they are consistent by construction.
+ */
+function criteriaIdsForSection<S extends CriterionSection>(
+  section: S
+): CriteriaIdsForSection<typeof ACCEPTANCE_CRITERION_CATALOG, S> {
+  return (ACCEPTANCE_CRITERION_CATALOG as readonly AcceptanceCriterionDefinition[])
+    .filter(criterion => criterion.section === section)
+    .map(criterion => criterion.id) as CriteriaIdsForSection<typeof ACCEPTANCE_CRITERION_CATALOG, S>;
+}
+
 /**
  * Administrative criteria
  */
-export const ADMINISTRATIVE_CRITERIA = ['A001'] as const;
+export const ADMINISTRATIVE_CRITERIA = criteriaIdsForSection('Administrative');
 
 /**
  * Shared/Common criteria - apply to all FOLIO modules
  */
-export const SHARED_CRITERIA = [
-  'S001', 'S002', 'S003', 'S004', 'S005', 'S006', 'S007',
-  'S008', 'S009', 'S010', 'S011', 'S012', 'S013', 'S014'
-] as const;
+export const SHARED_CRITERIA = criteriaIdsForSection('Shared/Common');
 
 /**
  * Backend criteria - specific to backend/server-side modules
  */
-export const BACKEND_CRITERIA = [
-  'B001', 'B002', 'B003', 'B004', 'B005', 'B006', 'B007', 'B008',
-  'B009', 'B010', 'B011', 'B012', 'B013', 'B014', 'B015', 'B016'
-] as const;
+export const BACKEND_CRITERIA = criteriaIdsForSection('Backend');
 
 /**
  * Frontend criteria - specific to frontend/UI modules
  */
-export const FRONTEND_CRITERIA = [
-  'F001', 'F002', 'F003', 'F004', 'F005', 'F006', 'F007'
-] as const;
+export const FRONTEND_CRITERIA = criteriaIdsForSection('Frontend');
 
 /**
  * Complete definitions of all criteria with descriptions
  */
-export const CRITERIA_DEFINITIONS: Record<string, CriterionDefinition> = {
-  // Administrative
-  'A001': {
-    id: 'A001',
-    description: 'Listed by Product Council with positive evaluation result',
-    section: 'Administrative'
-  },
-
-  // Shared/Common
-  'S001': {
-    id: 'S001',
-    description: 'Uses Apache 2.0 license',
-    section: 'Shared/Common'
-  },
-  'S002': {
-    id: 'S002',
-    description: 'Module build produces valid module descriptor',
-    section: 'Shared/Common'
-  },
-  'S003': {
-    id: 'S003',
-    description: 'Third-party dependencies comply with ASF license policy',
-    section: 'Shared/Common'
-  },
-  'S004': {
-    id: 'S004',
-    description: 'Installation documentation included',
-    section: 'Shared/Common'
-  },
-  'S005': {
-    id: 'S005',
-    description: 'Personal data form completed',
-    section: 'Shared/Common'
-  },
-  'S006': {
-    id: 'S006',
-    description: 'No sensitive info in git repository',
-    section: 'Shared/Common'
-  },
-  'S007': {
-    id: 'S007',
-    description: 'Written in officially supported technologies',
-    section: 'Shared/Common'
-  },
-  'S008': {
-    id: 'S008',
-    description: 'Uses existing FOLIO interfaces',
-    section: 'Shared/Common'
-  },
-  'S009': {
-    id: 'S009',
-    description: 'No unapproved FOLIO library dependencies',
-    section: 'Shared/Common'
-  },
-  'S010': {
-    id: 'S010',
-    description: 'Handles absence of third-party systems',
-    section: 'Shared/Common'
-  },
-  'S011': {
-    id: 'S011',
-    description: 'Passes Sonarqube security checks',
-    section: 'Shared/Common'
-  },
-  'S012': {
-    id: 'S012',
-    description: 'Uses officially supported build tools',
-    section: 'Shared/Common'
-  },
-  'S013': {
-    id: 'S013',
-    description: '80%+ unit test coverage',
-    section: 'Shared/Common'
-  },
-  'S014': {
-    id: 'S014',
-    description: 'Assigned to one application descriptor',
-    section: 'Shared/Common'
-  },
-
-  // Backend
-  'B001': {
-    id: 'B001',
-    description: 'Compliant Module Descriptor',
-    section: 'Backend'
-  },
-  'B002': {
-    id: 'B002',
-    description: 'API interface requirements in module descriptor',
-    section: 'Backend'
-  },
-  'B003': {
-    id: 'B003',
-    description: 'Implement all endpoints in Module Descriptor',
-    section: 'Backend'
-  },
-  'B004': {
-    id: 'B004',
-    description: 'Environment vars documented',
-    section: 'Backend'
-  },
-  'B005': {
-    id: 'B005',
-    description: 'Provide interfaces per naming conventions',
-    section: 'Backend'
-  },
-  'B006': {
-    id: 'B006',
-    description: 'OpenAPI documentation for endpoints',
-    section: 'Backend'
-  },
-  'B007': {
-    id: 'B007',
-    description: 'Appropriate endpoint permissions',
-    section: 'Backend'
-  },
-  'B008': {
-    id: 'B008',
-    description: 'Provide reference data',
-    section: 'Backend'
-  },
-  'B009': {
-    id: 'B009',
-    description: 'Integration tests in supported technology',
-    section: 'Backend'
-  },
-  'B010': {
-    id: 'B010',
-    description: 'Tenant data segregation',
-    section: 'Backend'
-  },
-  'B011': {
-    id: 'B011',
-    description: 'Restricted database schema access',
-    section: 'Backend'
-  },
-  'B012': {
-    id: 'B012',
-    description: 'Dependencies declared in README',
-    section: 'Backend'
-  },
-  'B013': {
-    id: 'B013',
-    description: 'Respond with tenant-specific content',
-    section: 'Backend'
-  },
-  'B014': {
-    id: 'B014',
-    description: 'Standard health check endpoint',
-    section: 'Backend'
-  },
-  'B015': {
-    id: 'B015',
-    description: 'High Availability compliance',
-    section: 'Backend'
-  },
-  'B016': {
-    id: 'B016',
-    description: 'Use only supported infrastructure technologies',
-    section: 'Backend'
-  },
-
-  // Frontend
-  'F001': {
-    id: 'F001',
-    description: 'API interface requirements in package.json',
-    section: 'Frontend'
-  },
-  'F002': {
-    id: 'F002',
-    description: 'E2E tests in supported technology',
-    section: 'Frontend'
-  },
-  'F003': {
-    id: 'F003',
-    description: 'i18n support via react-intl',
-    section: 'Frontend'
-  },
-  'F004': {
-    id: 'F004',
-    description: 'WCAG 2.1 AA compliance',
-    section: 'Frontend'
-  },
-  'F005': {
-    id: 'F005',
-    description: 'Use specified Stripes version',
-    section: 'Frontend'
-  },
-  'F006': {
-    id: 'F006',
-    description: 'Follow existing UI layouts/patterns',
-    section: 'Frontend'
-  },
-  'F007': {
-    id: 'F007',
-    description: 'Works in latest Chrome',
-    section: 'Frontend'
-  }
-};
+export const CRITERIA_DEFINITIONS: Record<string, CriterionDefinition> =
+  ACCEPTANCE_CRITERION_CATALOG.reduce<Record<string, CriterionDefinition>>((definitions, criterion) => {
+    definitions[criterion.id] = {
+      id: criterion.id,
+      description: criterion.description,
+      section: criterion.section
+    };
+    return definitions;
+  }, {});
 
 /**
  * All Java module criteria (combines administrative, shared, and backend)
  */
-export const JAVA_CRITERIA = [
+export const JAVA_CRITERIA: JavaCriteria = [
   ...ADMINISTRATIVE_CRITERIA,
   ...SHARED_CRITERIA,
   ...BACKEND_CRITERIA
-] as const;
+];
 
 /**
  * All available criteria across all module types
  */
-export const ALL_CRITERIA = [
+export const ALL_CRITERIA: AllCriteria = [
   ...ADMINISTRATIVE_CRITERIA,
   ...SHARED_CRITERIA,
   ...BACKEND_CRITERIA,
   ...FRONTEND_CRITERIA
-] as const;
-
-/**
- * Type definitions for criterion IDs
- */
-export type AdministrativeCriterionId = typeof ADMINISTRATIVE_CRITERIA[number];
-export type SharedCriterionId = typeof SHARED_CRITERIA[number];
-export type BackendCriterionId = typeof BACKEND_CRITERIA[number];
-export type FrontendCriterionId = typeof FRONTEND_CRITERIA[number];
-export type JavaCriterionId = typeof JAVA_CRITERIA[number];
-export type CriterionId = typeof ALL_CRITERIA[number];
+];
 
 /**
  * Criteria organized by section for easy lookup
@@ -292,17 +574,38 @@ export const CRITERIA_BY_SECTION = {
 export function getCriteriaForLanguage(language: string): readonly string[] {
   switch (language.toLowerCase()) {
     case 'java':
-      return JAVA_CRITERIA;
+      return getCriteriaForCatalogLanguage('java');
     case 'javascript':
     case 'typescript':
     case 'react':
-      return [...ADMINISTRATIVE_CRITERIA, ...SHARED_CRITERIA, ...FRONTEND_CRITERIA];
+      return getCriteriaForCatalogLanguage('javascript');
     default:
       throw new Error(
         `Unsupported language: ${language}. ` +
         `Supported languages are: java, javascript, typescript, react`
       );
   }
+}
+
+/**
+ * Get all criteria IDs in canonical order for a catalog language.
+ */
+export function getCriteriaForCatalogLanguage(language: CriterionLanguage): readonly string[] {
+  return (ACCEPTANCE_CRITERION_CATALOG as readonly AcceptanceCriterionDefinition[])
+    .filter(criterion => criterion.languages.includes(language))
+    .map(criterion => criterion.id);
+}
+
+/**
+ * Get all criteria IDs for a section and language in canonical order.
+ */
+export function getCriteriaForSection(
+  section: CriterionSection,
+  language: CriterionLanguage
+): readonly string[] {
+  return (ACCEPTANCE_CRITERION_CATALOG as readonly AcceptanceCriterionDefinition[])
+    .filter(criterion => criterion.section === section && criterion.languages.includes(language))
+    .map(criterion => criterion.id);
 }
 
 /**
@@ -341,4 +644,43 @@ export function getDescriptionForCriterion(criterionId: string): string {
  */
 export function getCriterionDefinition(criterionId: string): CriterionDefinition | undefined {
   return CRITERIA_DEFINITIONS[criterionId];
+}
+
+/**
+ * Get the catalog entry for a criterion ID.
+ */
+export function getAcceptanceCriterionDefinition(criterionId: string): AcceptanceCriterion | undefined {
+  return ACCEPTANCE_CRITERION_CATALOG.find(criterion => criterion.id === criterionId);
+}
+
+/**
+ * Create the catalog-defined fallback result for criteria without automated logic.
+ */
+export function createDefaultCriterionResult(
+  criterionId: string,
+  language: CriterionLanguage
+): CriterionResult {
+  const criterion = getAcceptanceCriterionDefinition(criterionId);
+  if (!criterion?.defaultEvaluation) {
+    throw new Error(`No default evaluation registered for criterion: ${criterionId}`);
+  }
+
+  const defaultEvaluation = criterion.defaultEvaluation;
+  const reason = defaultEvaluation.languageReasons?.[language] || defaultEvaluation.reason;
+
+  if (defaultEvaluation.type === 'manual_review') {
+    return {
+      criterionId,
+      status: EvaluationStatus.MANUAL,
+      evidence: reason,
+      details: HUMAN_REVIEW_DETAILS
+    };
+  }
+
+  return {
+    criterionId,
+    status: EvaluationStatus.MANUAL,
+    evidence: `${reason} - evaluation logic not yet implemented`,
+    details: HUMAN_REVIEW_DETAILS
+  };
 }

--- a/src/evaluators/base/catalog-section-evaluator.ts
+++ b/src/evaluators/base/catalog-section-evaluator.ts
@@ -1,0 +1,48 @@
+import { CriterionResult } from '../../types';
+import {
+  createDefaultCriterionResult,
+  CriterionLanguage,
+  CriterionSection,
+  getAcceptanceCriterionDefinition,
+  getCriteriaForSection
+} from '../../criteria-definitions';
+import { CriterionFunction } from '../../types';
+import { BaseSectionEvaluator } from './section-evaluator';
+
+/**
+ * Section evaluator that derives handled criteria and fallback results from
+ * the acceptance criterion catalog.
+ */
+export abstract class CatalogSectionEvaluator extends BaseSectionEvaluator {
+  readonly sectionName: string;
+  protected readonly language: CriterionLanguage;
+
+  constructor(
+    sectionName: CriterionSection,
+    language: CriterionLanguage,
+    handlerOverrides: Record<string, CriterionFunction> = {}
+  ) {
+    super();
+    this.sectionName = sectionName;
+    this.language = language;
+
+    for (const criterionId of getCriteriaForSection(sectionName, language)) {
+      const override = handlerOverrides[criterionId];
+      if (override) {
+        this.criterionHandlers.set(criterionId, override);
+        continue;
+      }
+
+      const definition = getAcceptanceCriterionDefinition(criterionId);
+      if (!definition?.defaultEvaluation) {
+        throw new Error(`No default evaluation or handler registered for criterion: ${criterionId}`);
+      }
+
+      this.criterionHandlers.set(criterionId, async () => this.createDefaultCatalogResult(criterionId));
+    }
+  }
+
+  private createDefaultCatalogResult(criterionId: string): CriterionResult {
+    return createDefaultCriterionResult(criterionId, this.language);
+  }
+}

--- a/src/evaluators/java-evaluator.ts
+++ b/src/evaluators/java-evaluator.ts
@@ -17,7 +17,7 @@ export class JavaEvaluator extends CompositeLanguageEvaluator {
 
   constructor() {
     super();
-    this.administrativeEvaluator = new AdministrativeEvaluator();
+    this.administrativeEvaluator = new AdministrativeEvaluator('java');
     this.sharedEvaluator = new JavaSharedEvaluator();
     this.backendEvaluator = new BackendEvaluator();
   }

--- a/src/evaluators/java/backend-evaluator.ts
+++ b/src/evaluators/java/backend-evaluator.ts
@@ -1,94 +1,11 @@
-import { BaseSectionEvaluator } from '../base/section-evaluator';
-import { CriterionResult } from '../../types';
+import { CatalogSectionEvaluator } from '../base/catalog-section-evaluator';
 
 /**
  * Evaluator for Backend criteria (B001-B016)
  * Handles backend-specific requirements for FOLIO modules
  */
-export class BackendEvaluator extends BaseSectionEvaluator {
-  readonly sectionName = 'Backend';
-
+export class BackendEvaluator extends CatalogSectionEvaluator {
   constructor() {
-    super();
-    this.criterionHandlers.set('B001', this.evaluateB001.bind(this));
-    this.criterionHandlers.set('B002', this.evaluateB002.bind(this));
-    this.criterionHandlers.set('B003', this.evaluateB003.bind(this));
-    this.criterionHandlers.set('B004', this.evaluateB004.bind(this));
-    this.criterionHandlers.set('B005', this.evaluateB005.bind(this));
-    this.criterionHandlers.set('B006', this.evaluateB006.bind(this));
-    this.criterionHandlers.set('B007', this.evaluateB007.bind(this));
-    this.criterionHandlers.set('B008', this.evaluateB008.bind(this));
-    this.criterionHandlers.set('B009', this.evaluateB009.bind(this));
-    this.criterionHandlers.set('B010', this.evaluateB010.bind(this));
-    this.criterionHandlers.set('B011', this.evaluateB011.bind(this));
-    this.criterionHandlers.set('B012', this.evaluateB012.bind(this));
-    this.criterionHandlers.set('B013', this.evaluateB013.bind(this));
-    this.criterionHandlers.set('B014', this.evaluateB014.bind(this));
-    this.criterionHandlers.set('B015', this.evaluateB015.bind(this));
-    this.criterionHandlers.set('B016', this.evaluateB016.bind(this));
-  }
-
-  private async evaluateB001(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('B001', 'API design and RESTful principles');
-  }
-
-  private async evaluateB002(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('B002', 'Database design and schema management');
-  }
-
-  private async evaluateB003(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('B003', 'Error handling and validation');
-  }
-
-  private async evaluateB004(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('B004', 'Authentication and authorization');
-  }
-
-  private async evaluateB005(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('B005', 'Data persistence and transactions');
-  }
-
-  private async evaluateB006(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('B006', 'Caching strategy');
-  }
-
-  private async evaluateB007(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('B007', 'Event-driven architecture');
-  }
-
-  private async evaluateB008(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('B008', 'Microservice architecture compliance');
-  }
-
-  private async evaluateB009(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('B009', 'Health checks and monitoring endpoints');
-  }
-
-  private async evaluateB010(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('B010', 'Scalability and load handling');
-  }
-
-  private async evaluateB011(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('B011', 'Data migration and backward compatibility');
-  }
-
-  private async evaluateB012(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('B012', 'Environment configuration');
-  }
-
-  private async evaluateB013(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('B013', 'Dependency injection and IoC');
-  }
-
-  private async evaluateB014(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('B014', 'API versioning strategy');
-  }
-
-  private async evaluateB015(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('B015', 'Resource management');
-  }
-
-  private async evaluateB016(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('B016', 'Integration testing');
+    super('Backend', 'java');
   }
 }

--- a/src/evaluators/java/java-shared-evaluator.ts
+++ b/src/evaluators/java/java-shared-evaluator.ts
@@ -6,4 +6,7 @@ import { SharedEvaluator } from '../shared/shared-evaluator';
  * since the generic descriptions match Java usage.
  */
 export class JavaSharedEvaluator extends SharedEvaluator {
+  constructor() {
+    super('java');
+  }
 }

--- a/src/evaluators/javascript-evaluator.ts
+++ b/src/evaluators/javascript-evaluator.ts
@@ -18,7 +18,7 @@ export class JavaScriptEvaluator extends CompositeLanguageEvaluator {
 
   constructor() {
     super();
-    this.administrativeEvaluator = new AdministrativeEvaluator();
+    this.administrativeEvaluator = new AdministrativeEvaluator('javascript');
     this.sharedEvaluator = new JavaScriptSharedEvaluator();
     this.frontendEvaluator = new FrontendEvaluator();
   }

--- a/src/evaluators/javascript/frontend-evaluator.ts
+++ b/src/evaluators/javascript/frontend-evaluator.ts
@@ -1,49 +1,11 @@
-import { BaseSectionEvaluator } from '../base/section-evaluator';
-import { CriterionResult } from '../../types';
+import { CatalogSectionEvaluator } from '../base/catalog-section-evaluator';
 
 /**
  * Evaluator for Frontend criteria (F001-F007)
  * Handles UI-specific requirements for FOLIO modules
  */
-export class FrontendEvaluator extends BaseSectionEvaluator {
-  readonly sectionName = 'Frontend';
-
+export class FrontendEvaluator extends CatalogSectionEvaluator {
   constructor() {
-    super();
-    this.criterionHandlers.set('F001', this.evaluateF001.bind(this));
-    this.criterionHandlers.set('F002', this.evaluateF002.bind(this));
-    this.criterionHandlers.set('F003', this.evaluateF003.bind(this));
-    this.criterionHandlers.set('F004', this.evaluateF004.bind(this));
-    this.criterionHandlers.set('F005', this.evaluateF005.bind(this));
-    this.criterionHandlers.set('F006', this.evaluateF006.bind(this));
-    this.criterionHandlers.set('F007', this.evaluateF007.bind(this));
-  }
-
-  private async evaluateF001(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('F001', 'API interface requirements in package.json');
-  }
-
-  private async evaluateF002(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('F002', 'E2E tests in supported technology (Cypress, BigTest, etc.)');
-  }
-
-  private async evaluateF003(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('F003', 'Internationalization support via react-intl');
-  }
-
-  private async evaluateF004(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('F004', 'WCAG 2.1 AA accessibility compliance');
-  }
-
-  private async evaluateF005(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('F005', 'Use of specified Stripes framework version');
-  }
-
-  private async evaluateF006(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('F006', 'Adherence to existing FOLIO UI layouts and patterns');
-  }
-
-  private async evaluateF007(repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('F007', 'Browser compatibility with latest Chrome');
+    super('Frontend', 'javascript');
   }
 }

--- a/src/evaluators/javascript/javascript-shared-evaluator.ts
+++ b/src/evaluators/javascript/javascript-shared-evaluator.ts
@@ -1,49 +1,11 @@
 import { SharedEvaluator } from '../shared/shared-evaluator';
-import { CriterionResult } from '../../types';
 
 /**
  * Evaluator for Shared/Common criteria (S001-S014) for JavaScript/UI modules.
  * Extends SharedEvaluator with JavaScript-specific description overrides.
  */
 export class JavaScriptSharedEvaluator extends SharedEvaluator {
-
   constructor() {
-    super();
-    // Override handlers with JS-specific descriptions
-    this.criterionHandlers.set('S002', this.evaluateS002JS.bind(this));
-    this.criterionHandlers.set('S007', this.evaluateS007JS.bind(this));
-    this.criterionHandlers.set('S008', this.evaluateS008JS.bind(this));
-    this.criterionHandlers.set('S009', this.evaluateS009JS.bind(this));
-    this.criterionHandlers.set('S011', this.evaluateS011JS.bind(this));
-    this.criterionHandlers.set('S012', this.evaluateS012JS.bind(this));
-    this.criterionHandlers.set('S013', this.evaluateS013JS.bind(this));
-  }
-
-  private async evaluateS002JS(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('S002', 'package.json and stripes metadata validation');
-  }
-
-  private async evaluateS007JS(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('S007', 'Supported technologies (React, Node.js, Stripes)');
-  }
-
-  private async evaluateS008JS(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('S008', 'FOLIO Stripes interface usage');
-  }
-
-  private async evaluateS009JS(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('S009', 'Approved npm package dependencies');
-  }
-
-  private async evaluateS011JS(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('S011', 'Sonarqube security configuration');
-  }
-
-  private async evaluateS012JS(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('S012', 'Build tools (npm/yarn)');
-  }
-
-  private async evaluateS013JS(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('S013', 'Unit test coverage (Jest/Istanbul)');
+    super('javascript');
   }
 }

--- a/src/evaluators/javascript/javascript-shared-evaluator.ts
+++ b/src/evaluators/javascript/javascript-shared-evaluator.ts
@@ -2,7 +2,8 @@ import { SharedEvaluator } from '../shared/shared-evaluator';
 
 /**
  * Evaluator for Shared/Common criteria (S001-S014) for JavaScript/UI modules.
- * Extends SharedEvaluator with JavaScript-specific description overrides.
+ * Selects the 'javascript' catalog language so JS-specific fallback text
+ * (languageReasons) is applied; it adds no per-criterion logic of its own.
  */
 export class JavaScriptSharedEvaluator extends SharedEvaluator {
   constructor() {

--- a/src/evaluators/shared/administrative-evaluator.ts
+++ b/src/evaluators/shared/administrative-evaluator.ts
@@ -1,22 +1,12 @@
-import { BaseSectionEvaluator } from '../base/section-evaluator';
-import { CriterionResult } from '../../types';
+import { CriterionLanguage } from '../../criteria-definitions';
+import { CatalogSectionEvaluator } from '../base/catalog-section-evaluator';
 
 /**
  * Evaluator for Administrative criteria (A001)
  * Handles administrative requirements for FOLIO modules
  */
-export class AdministrativeEvaluator extends BaseSectionEvaluator {
-  readonly sectionName = 'Administrative';
-
-  constructor() {
-    super();
-    this.criterionHandlers.set('A001', this.evaluateA001.bind(this));
-  }
-
-  private async evaluateA001(repoPath: string): Promise<CriterionResult> {
-    return this.createManualReviewResult(
-      'A001',
-      'Product Council approval verification requires manual review'
-    );
+export class AdministrativeEvaluator extends CatalogSectionEvaluator {
+  constructor(language: CriterionLanguage = 'java') {
+    super('Administrative', language);
   }
 }

--- a/src/evaluators/shared/shared-evaluator.ts
+++ b/src/evaluators/shared/shared-evaluator.ts
@@ -5,11 +5,11 @@ import { LicenseUtils } from '../../utils/license-utils';
 import { evaluateS003ThirdPartyLicenses } from '../../utils/license-compliance-evaluator';
 
 /**
- * Abstract base class for Shared/Common criteria (S001-S014).
- * Registers default handlers for all shared criteria. Language-specific subclasses
- * can override individual handlers by calling criterionHandlers.set() in their
- * constructor (Map.set on existing keys replaces the value while preserving
- * insertion-order position).
+ * Abstract base class for Shared/Common criteria (S001-S014). Handled criterion
+ * IDs and their fallback results are derived from the acceptance-criterion catalog
+ * by CatalogSectionEvaluator. Automated criteria are supplied as handler overrides
+ * to super() (here S001 and S003); every other criterion falls back to the
+ * catalog-defined default result for the given language.
  */
 export abstract class SharedEvaluator extends CatalogSectionEvaluator {
   constructor(language: CriterionLanguage = 'java') {

--- a/src/evaluators/shared/shared-evaluator.ts
+++ b/src/evaluators/shared/shared-evaluator.ts
@@ -1,5 +1,6 @@
-import { BaseSectionEvaluator } from '../base/section-evaluator';
 import { CriterionResult } from '../../types';
+import { CriterionLanguage } from '../../criteria-definitions';
+import { CatalogSectionEvaluator } from '../base/catalog-section-evaluator';
 import { LicenseUtils } from '../../utils/license-utils';
 import { evaluateS003ThirdPartyLicenses } from '../../utils/license-compliance-evaluator';
 
@@ -10,80 +11,19 @@ import { evaluateS003ThirdPartyLicenses } from '../../utils/license-compliance-e
  * constructor (Map.set on existing keys replaces the value while preserving
  * insertion-order position).
  */
-export abstract class SharedEvaluator extends BaseSectionEvaluator {
-  readonly sectionName = 'Shared/Common';
-
-  constructor() {
-    super();
-    this.criterionHandlers.set('S001', this.evaluateS001.bind(this));
-    this.criterionHandlers.set('S002', this.evaluateS002.bind(this));
-    this.criterionHandlers.set('S003', this.evaluateS003.bind(this));
-    this.criterionHandlers.set('S004', this.evaluateS004.bind(this));
-    this.criterionHandlers.set('S005', this.evaluateS005.bind(this));
-    this.criterionHandlers.set('S006', this.evaluateS006.bind(this));
-    this.criterionHandlers.set('S007', this.evaluateS007.bind(this));
-    this.criterionHandlers.set('S008', this.evaluateS008.bind(this));
-    this.criterionHandlers.set('S009', this.evaluateS009.bind(this));
-    this.criterionHandlers.set('S010', this.evaluateS010.bind(this));
-    this.criterionHandlers.set('S011', this.evaluateS011.bind(this));
-    this.criterionHandlers.set('S012', this.evaluateS012.bind(this));
-    this.criterionHandlers.set('S013', this.evaluateS013.bind(this));
-    this.criterionHandlers.set('S014', this.evaluateS014.bind(this));
+export abstract class SharedEvaluator extends CatalogSectionEvaluator {
+  constructor(language: CriterionLanguage = 'java') {
+    super('Shared/Common', language, {
+      S001: async (repoPath: string) => this.evaluateS001(repoPath),
+      S003: async (repoPath: string) => this.evaluateS003(repoPath)
+    });
   }
 
   private async evaluateS001(repoPath: string): Promise<CriterionResult> {
     return await LicenseUtils.checkApache2License(repoPath, 'S001');
   }
 
-  protected async evaluateS002(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('S002', 'Module descriptor validation');
-  }
-
   private async evaluateS003(repoPath: string): Promise<CriterionResult> {
     return await evaluateS003ThirdPartyLicenses(repoPath);
-  }
-
-  private async evaluateS004(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('S004', 'README file evaluation');
-  }
-
-  private async evaluateS005(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('S005', 'Version control and branching strategy');
-  }
-
-  private async evaluateS006(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('S006', 'Code quality and static analysis');
-  }
-
-  protected async evaluateS007(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('S007', 'Testing requirements');
-  }
-
-  protected async evaluateS008(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('S008', 'Documentation requirements');
-  }
-
-  protected async evaluateS009(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('S009', 'Security requirements');
-  }
-
-  private async evaluateS010(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('S010', 'Performance requirements');
-  }
-
-  protected async evaluateS011(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('S011', 'Accessibility requirements');
-  }
-
-  protected async evaluateS012(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('S012', 'Internationalization requirements');
-  }
-
-  protected async evaluateS013(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('S013', 'Configuration management');
-  }
-
-  private async evaluateS014(_repoPath: string): Promise<CriterionResult> {
-    return this.createNotImplementedResult('S014', 'Monitoring and logging');
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export { JavaScriptSharedEvaluator } from './evaluators/javascript/javascript-sh
 export { BackendEvaluator } from './evaluators/java/backend-evaluator';
 export { FrontendEvaluator } from './evaluators/javascript/frontend-evaluator';
 export { BaseSectionEvaluator } from './evaluators/base/section-evaluator';
+export { CatalogSectionEvaluator } from './evaluators/base/catalog-section-evaluator';
 export { CompositeLanguageEvaluator } from './evaluators/base/composite-language-evaluator';
 
 // Export types

--- a/src/utils/license-compliance-evaluator.ts
+++ b/src/utils/license-compliance-evaluator.ts
@@ -5,6 +5,16 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { getLogger } from './logger';
 
+export interface ThirdPartyLicenseEvaluatorAdapters {
+  extractDependencies(repoPath: string): Promise<{
+    dependencies: Dependency[];
+    errors: DependencyExtractionError[];
+    warnings: DependencyExtractionError[];
+  }>;
+  readReadmeContent(repoPath: string): string;
+  checkCompliance(dependencies: Dependency[], readmeContent: string): ComplianceResult;
+}
+
 /**
  * Format extraction errors into a detailed string for inclusion in criterion results.
  */
@@ -124,6 +134,96 @@ export function determineComplianceStatus(
 }
 
 /**
+ * Deep module for evaluating third-party license compliance (S003).
+ */
+export class ThirdPartyLicenseEvaluator {
+  constructor(
+    private readonly adapters: ThirdPartyLicenseEvaluatorAdapters = {
+      extractDependencies: getDependencies,
+      readReadmeContent: findReadmeContent,
+      checkCompliance: checkLicenseCompliance
+    }
+  ) {}
+
+  /**
+   * Evaluates third-party license compliance for any project type.
+   */
+  async evaluate(repoPath: string, criterionId: string = 'S003'): Promise<CriterionResult> {
+    try {
+      const extractionResult = await this.adapters.extractDependencies(repoPath);
+      const { dependencies, errors, warnings } = extractionResult;
+
+      if (errors.length > 0) {
+        return this.createExtractionErrorResult(criterionId, errors);
+      }
+
+      if (dependencies.length === 0) {
+        return this.createNoDependenciesResult(criterionId, warnings);
+      }
+
+      const readmeContent = this.adapters.readReadmeContent(repoPath);
+      const complianceResult = this.adapters.checkCompliance(dependencies, readmeContent);
+      const evidence = buildEvidenceSummary(dependencies);
+
+      return determineComplianceStatus(
+        criterionId,
+        complianceResult,
+        evidence,
+        warnings,
+        this.hasFallbackWarning(warnings)
+      );
+    } catch (error) {
+      getLogger().warn(`Error evaluating ${criterionId}:`, error);
+      return {
+        criterionId,
+        status: EvaluationStatus.MANUAL,
+        evidence: 'Error occurred during dependency analysis',
+        details: `Failed to analyze third-party license compliance: ${error instanceof Error ? error.message : 'Unknown error'}. Manual review required.`
+      };
+    }
+  }
+
+  private createExtractionErrorResult(
+    criterionId: string,
+    errors: DependencyExtractionError[]
+  ): CriterionResult {
+    const errorDetails = formatExtractionErrors(errors);
+    return {
+      criterionId,
+      status: EvaluationStatus.MANUAL,
+      evidence: `Failed to extract dependencies due to ${errors.length} error(s)`,
+      details: `Dependency extraction errors:\n${errorDetails}\n\nManual review required to verify third-party license compliance.`
+    };
+  }
+
+  private createNoDependenciesResult(
+    criterionId: string,
+    warnings: DependencyExtractionError[]
+  ): CriterionResult {
+    const warningInfo = warnings.length > 0
+      ? `\n\nWarnings:\n${warnings.map(w => `  - [${w.source}] ${w.message}`).join('\n')}`
+      : '';
+
+    return {
+      criterionId,
+      status: EvaluationStatus.MANUAL,
+      evidence: 'No third-party dependencies found',
+      details: `Repository appears to have no third-party dependencies. This is uncommon and may indicate a library project, configuration-only project, or build tool detection issue. Manual review required to confirm compliance.${warningInfo}`
+    };
+  }
+
+  private hasFallbackWarning(warnings: DependencyExtractionError[]): boolean {
+    return warnings.some(w =>
+      w.message.includes('transitive dependencies unavailable') ||
+      w.message.includes('fallback') ||
+      w.message.includes('Fallback mode')
+    );
+  }
+}
+
+const defaultThirdPartyLicenseEvaluator = new ThirdPartyLicenseEvaluator();
+
+/**
  * Evaluates third-party license compliance (S003) for any project type.
  * This is a language-agnostic evaluation that works with Maven, Gradle, and npm projects
  * through the dependency-orchestrator auto-detection.
@@ -132,52 +232,5 @@ export function determineComplianceStatus(
  * @returns CriterionResult for S003 evaluation
  */
 export async function evaluateS003ThirdPartyLicenses(repoPath: string): Promise<CriterionResult> {
-  try {
-    const extractionResult = await getDependencies(repoPath);
-    const { dependencies, errors, warnings } = extractionResult;
-
-    if (errors.length > 0) {
-      const errorDetails = formatExtractionErrors(errors);
-      return {
-        criterionId: 'S003',
-        status: EvaluationStatus.MANUAL,
-        evidence: `Failed to extract dependencies due to ${errors.length} error(s)`,
-        details: `Dependency extraction errors:\n${errorDetails}\n\nManual review required to verify third-party license compliance.`
-      };
-    }
-
-    if (dependencies.length === 0) {
-      const warningInfo = warnings.length > 0
-        ? `\n\nWarnings:\n${warnings.map(w => `  - [${w.source}] ${w.message}`).join('\n')}`
-        : '';
-
-      return {
-        criterionId: 'S003',
-        status: EvaluationStatus.MANUAL,
-        evidence: 'No third-party dependencies found',
-        details: `Repository appears to have no third-party dependencies. This is uncommon and may indicate a library project, configuration-only project, or build tool detection issue. Manual review required to confirm compliance.${warningInfo}`
-      };
-    }
-
-    const readmeContent = findReadmeContent(repoPath);
-    const complianceResult = checkLicenseCompliance(dependencies, readmeContent);
-    const evidence = buildEvidenceSummary(dependencies);
-
-    const hasFallbackWarning = warnings.some(w =>
-      w.message.includes('transitive dependencies unavailable') ||
-      w.message.includes('fallback') ||
-      w.message.includes('Fallback mode')
-    );
-
-    return determineComplianceStatus('S003', complianceResult, evidence, warnings, hasFallbackWarning);
-
-  } catch (error) {
-    getLogger().warn('Error evaluating S003:', error);
-    return {
-      criterionId: 'S003',
-      status: EvaluationStatus.MANUAL,
-      evidence: 'Error occurred during dependency analysis',
-      details: `Failed to analyze third-party license compliance: ${error instanceof Error ? error.message : 'Unknown error'}. Manual review required.`
-    };
-  }
+  return await defaultThirdPartyLicenseEvaluator.evaluate(repoPath);
 }

--- a/src/utils/report-generator.ts
+++ b/src/utils/report-generator.ts
@@ -1,16 +1,19 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { EvaluationResult, ReportOptions, EvaluationStatus } from '../types';
+import { EvaluationResult, ReportOptions } from '../types';
 import { getLogger } from './logger';
+import { EvaluationReportRenderer, ReportRenderer } from './report-renderer';
 
 /**
  * Generates HTML and JSON reports from evaluation results
  */
 export class ReportGenerator {
   private outputDir: string;
+  private renderer: ReportRenderer;
 
-  constructor(outputDir: string = './reports') {
+  constructor(outputDir: string = './reports', renderer: ReportRenderer = new EvaluationReportRenderer()) {
     this.outputDir = outputDir;
+    this.renderer = renderer;
   }
 
   /**
@@ -54,7 +57,7 @@ export class ReportGenerator {
    * @param outputPath Path to save JSON report
    */
   private async generateJsonReport(result: EvaluationResult, outputPath: string): Promise<void> {
-    const jsonContent = JSON.stringify(result, null, 2);
+    const jsonContent = this.renderer.renderJson(result);
     await fs.writeFile(outputPath, jsonContent);
     getLogger().info(`JSON report generated: ${outputPath}`);
   }
@@ -65,308 +68,8 @@ export class ReportGenerator {
    * @param outputPath Path to save HTML report
    */
   private async generateHtmlReport(result: EvaluationResult, outputPath: string): Promise<void> {
-    const htmlContent = this.generateHtmlContent(result);
+    const htmlContent = this.renderer.renderHtml(result);
     await fs.writeFile(outputPath, htmlContent);
     getLogger().info(`HTML report generated: ${outputPath}`);
-  }
-
-  /**
-   * Generate HTML content for the report
-   * @param result Evaluation result
-   * @returns string HTML content
-   */
-  private generateHtmlContent(result: EvaluationResult): string {
-    const stats = this.calculateStats(result);
-    
-    return `
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>FOLIO Module Evaluation Report - ${result.moduleName}</title>
-    <style>
-        body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            margin: 0;
-            padding: 20px;
-            background-color: #f5f5f5;
-        }
-        
-        .container {
-            max-width: 1200px;
-            margin: 0 auto;
-            background: white;
-            border-radius: 8px;
-            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-            overflow: hidden;
-        }
-        
-        .header {
-            background: #2c5282;
-            color: white;
-            padding: 20px;
-        }
-        
-        .header h1 {
-            margin: 0;
-            font-size: 2rem;
-        }
-        
-        .metadata {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 15px;
-            margin-top: 15px;
-        }
-        
-        .metadata-item {
-            background: rgba(255,255,255,0.1);
-            padding: 10px;
-            border-radius: 4px;
-        }
-        
-        .metadata-label {
-            font-weight: bold;
-            font-size: 0.9rem;
-            opacity: 0.8;
-        }
-        
-        .stats {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-            gap: 20px;
-            padding: 20px;
-            background: #f8f9fa;
-        }
-        
-        .stat-card {
-            text-align: center;
-            padding: 15px;
-            background: white;
-            border-radius: 8px;
-            border-left: 4px solid;
-        }
-        
-        .stat-card.pass { border-left-color: #28a745; }
-        .stat-card.fail { border-left-color: #dc3545; }
-        .stat-card.manual { border-left-color: #ffc107; }
-        .stat-card.not_applicable { border-left-color: #6c757d; }
-        
-        .stat-number {
-            font-size: 2rem;
-            font-weight: bold;
-            margin-bottom: 5px;
-        }
-        
-        .stat-label {
-            color: #6c757d;
-            font-size: 0.9rem;
-        }
-        
-        .criteria-section {
-            padding: 20px;
-        }
-        
-        .criteria-section h2 {
-            color: #2c5282;
-            border-bottom: 2px solid #e9ecef;
-            padding-bottom: 10px;
-        }
-        
-        .criterion {
-            border: 1px solid #e9ecef;
-            border-radius: 6px;
-            margin-bottom: 15px;
-            overflow: hidden;
-        }
-        
-        .criterion-header {
-            padding: 15px;
-            font-weight: bold;
-            display: flex;
-            align-items: center;
-            gap: 10px;
-        }
-        
-        .criterion-header.pass { background: #d4edda; color: #155724; }
-        .criterion-header.fail { background: #f8d7da; color: #721c24; }
-        .criterion-header.manual { background: #fff3cd; color: #856404; }
-        .criterion-header.not_applicable { background: #e9ecef; color: #495057; }
-        
-        .status-badge {
-            padding: 4px 8px;
-            border-radius: 12px;
-            font-size: 0.8rem;
-            font-weight: bold;
-            text-transform: uppercase;
-        }
-        
-        .status-badge.pass { background: #28a745; color: white; }
-        .status-badge.fail { background: #dc3545; color: white; }
-        .status-badge.manual { background: #ffc107; color: #212529; }
-        .status-badge.not_applicable { background: #6c757d; color: white; }
-        
-        .criterion-content {
-            padding: 15px;
-            background: #f8f9fa;
-        }
-        
-        .criterion-description {
-            margin-bottom: 10px;
-            font-style: italic;
-            color: #6c757d;
-        }
-        
-        .evidence {
-            background: white;
-            padding: 10px;
-            border-radius: 4px;
-            border-left: 3px solid #007bff;
-            margin-top: 10px;
-        }
-        
-        .details {
-            margin-top: 10px;
-            font-size: 0.9rem;
-            color: #6c757d;
-        }
-        
-        .footer {
-            padding: 20px;
-            text-align: center;
-            background: #f8f9fa;
-            color: #6c757d;
-            font-size: 0.9rem;
-        }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <div class="header">
-            <h1>FOLIO Module Evaluation Report</h1>
-            <div class="metadata">
-                <div class="metadata-item">
-                    <div class="metadata-label">Module Name</div>
-                    <div>${result.moduleName}</div>
-                </div>
-                <div class="metadata-item">
-                    <div class="metadata-label">Language</div>
-                    <div>${result.language}</div>
-                </div>
-                <div class="metadata-item">
-                    <div class="metadata-label">Repository</div>
-                    <div><a href="${result.repositoryUrl}" target="_blank" style="color: #87ceeb;">${result.repositoryUrl}</a></div>
-                </div>
-                <div class="metadata-item">
-                    <div class="metadata-label">Evaluated At</div>
-                    <div>${result.evaluatedAt.toLocaleString()}</div>
-                </div>
-            </div>
-        </div>
-        
-        <div class="stats">
-            <div class="stat-card pass">
-                <div class="stat-number">${stats.pass}</div>
-                <div class="stat-label">Passed</div>
-            </div>
-            <div class="stat-card fail">
-                <div class="stat-number">${stats.fail}</div>
-                <div class="stat-label">Failed</div>
-            </div>
-            <div class="stat-card manual">
-                <div class="stat-number">${stats.manual}</div>
-                <div class="stat-label">Manual Review</div>
-            </div>
-            <div class="stat-card not_applicable">
-                <div class="stat-number">${stats.notApplicable}</div>
-                <div class="stat-label">Not Applicable</div>
-            </div>
-            <div class="stat-card">
-                <div class="stat-number">${stats.total}</div>
-                <div class="stat-label">Total Criteria</div>
-            </div>
-        </div>
-        
-        <div class="criteria-section">
-            <h2>Evaluation Results</h2>
-            ${this.generateCriteriaHtml(result)}
-        </div>
-        
-        <div class="footer">
-            Generated by FOLIO Module Evaluator | 
-            Report created on ${new Date().toLocaleString()}
-        </div>
-    </div>
-</body>
-</html>
-`;
-  }
-
-  /**
-   * Escape HTML special characters to prevent XSS
-   * @param text Text to escape
-   * @returns Escaped text
-   */
-  private escapeHtml(text: string): string {
-    const htmlEscapes: { [key: string]: string } = {
-      '&': '&amp;',
-      '<': '&lt;',
-      '>': '&gt;',
-      '"': '&quot;',
-      "'": '&#39;'
-    };
-    return text.replace(/[&<>"']/g, char => htmlEscapes[char]);
-  }
-
-  /**
-   * Convert plain text to HTML with line breaks
-   * @param text Plain text with newlines
-   * @returns HTML with <br> tags
-   */
-  private textToHtml(text: string): string {
-    return this.escapeHtml(text).replace(/\n/g, '<br>');
-  }
-
-  /**
-   * Generate HTML for criteria results
-   * @param result Evaluation result
-   * @returns string HTML content for criteria
-   */
-  private generateCriteriaHtml(result: EvaluationResult): string {
-    return result.criteria.map(criterion => `
-        <div class="criterion">
-            <div class="criterion-header ${criterion.status}">
-                <span class="status-badge ${criterion.status}">${criterion.status}</span>
-                <span>Criterion ${criterion.criterionId}</span>
-            </div>
-            <div class="criterion-content">
-                <div class="evidence">
-                    <strong>Evidence:</strong> ${this.escapeHtml(criterion.evidence)}
-                </div>
-                ${criterion.details ? `<div class="details">${this.textToHtml(criterion.details)}</div>` : ''}
-            </div>
-        </div>
-    `).join('');
-  }
-
-  /**
-   * Calculate statistics from evaluation results
-   * @param result Evaluation result
-   * @returns Stats object
-   */
-  private calculateStats(result: EvaluationResult): { pass: number; fail: number; manual: number; notApplicable: number; total: number } {
-    const pass = result.criteria.filter(c => c.status === EvaluationStatus.PASS).length;
-    const fail = result.criteria.filter(c => c.status === EvaluationStatus.FAIL).length;
-    const manual = result.criteria.filter(c => c.status === EvaluationStatus.MANUAL).length;
-    const notApplicable = result.criteria.filter(c => c.status === EvaluationStatus.NOT_APPLICABLE).length;
-
-    return {
-      pass,
-      fail,
-      manual,
-      notApplicable,
-      total: result.criteria.length
-    };
   }
 }

--- a/src/utils/report-renderer.ts
+++ b/src/utils/report-renderer.ts
@@ -14,7 +14,8 @@ export interface ReportRenderer {
 }
 
 /**
- * Renders evaluation reports without owning filesystem persistence.
+ * Produces JSON and HTML report strings from an EvaluationResult.
+ * Pure transformation: no I/O, no file writes.
  */
 export class EvaluationReportRenderer implements ReportRenderer {
   renderJson(result: EvaluationResult): string {
@@ -249,6 +250,8 @@ export class EvaluationReportRenderer implements ReportRenderer {
 `;
   }
 
+  // Escapes HTML special characters to prevent XSS from untrusted evidence/details
+  // text interpolated into the generated report (see generateCriteriaHtml).
   escapeHtml(text: string): string {
     const htmlEscapes: { [key: string]: string } = {
       '&': '&amp;',

--- a/src/utils/report-renderer.ts
+++ b/src/utils/report-renderer.ts
@@ -1,0 +1,298 @@
+import { EvaluationResult, EvaluationStatus } from '../types';
+
+export interface EvaluationReportStats {
+  pass: number;
+  fail: number;
+  manual: number;
+  notApplicable: number;
+  total: number;
+}
+
+export interface ReportRenderer {
+  renderJson(result: EvaluationResult): string;
+  renderHtml(result: EvaluationResult): string;
+}
+
+/**
+ * Renders evaluation reports without owning filesystem persistence.
+ */
+export class EvaluationReportRenderer implements ReportRenderer {
+  renderJson(result: EvaluationResult): string {
+    return JSON.stringify(result, null, 2);
+  }
+
+  renderHtml(result: EvaluationResult): string {
+    const stats = this.calculateStats(result);
+
+    return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FOLIO Module Evaluation Report - ${result.moduleName}</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+            overflow: hidden;
+        }
+        
+        .header {
+            background: #2c5282;
+            color: white;
+            padding: 20px;
+        }
+        
+        .header h1 {
+            margin: 0;
+            font-size: 2rem;
+        }
+        
+        .metadata {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 15px;
+            margin-top: 15px;
+        }
+        
+        .metadata-item {
+            background: rgba(255,255,255,0.1);
+            padding: 10px;
+            border-radius: 4px;
+        }
+        
+        .metadata-label {
+            font-weight: bold;
+            font-size: 0.9rem;
+            opacity: 0.8;
+        }
+        
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 20px;
+            padding: 20px;
+            background: #f8f9fa;
+        }
+        
+        .stat-card {
+            text-align: center;
+            padding: 15px;
+            background: white;
+            border-radius: 8px;
+            border-left: 4px solid;
+        }
+        
+        .stat-card.pass { border-left-color: #28a745; }
+        .stat-card.fail { border-left-color: #dc3545; }
+        .stat-card.manual { border-left-color: #ffc107; }
+        .stat-card.not_applicable { border-left-color: #6c757d; }
+        
+        .stat-number {
+            font-size: 2rem;
+            font-weight: bold;
+            margin-bottom: 5px;
+        }
+        
+        .stat-label {
+            color: #6c757d;
+            font-size: 0.9rem;
+        }
+        
+        .criteria-section {
+            padding: 20px;
+        }
+        
+        .criteria-section h2 {
+            color: #2c5282;
+            border-bottom: 2px solid #e9ecef;
+            padding-bottom: 10px;
+        }
+        
+        .criterion {
+            border: 1px solid #e9ecef;
+            border-radius: 6px;
+            margin-bottom: 15px;
+            overflow: hidden;
+        }
+        
+        .criterion-header {
+            padding: 15px;
+            font-weight: bold;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+        
+        .criterion-header.pass { background: #d4edda; color: #155724; }
+        .criterion-header.fail { background: #f8d7da; color: #721c24; }
+        .criterion-header.manual { background: #fff3cd; color: #856404; }
+        .criterion-header.not_applicable { background: #e9ecef; color: #495057; }
+        
+        .status-badge {
+            padding: 4px 8px;
+            border-radius: 12px;
+            font-size: 0.8rem;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+        
+        .status-badge.pass { background: #28a745; color: white; }
+        .status-badge.fail { background: #dc3545; color: white; }
+        .status-badge.manual { background: #ffc107; color: #212529; }
+        .status-badge.not_applicable { background: #6c757d; color: white; }
+        
+        .criterion-content {
+            padding: 15px;
+            background: #f8f9fa;
+        }
+        
+        .criterion-description {
+            margin-bottom: 10px;
+            font-style: italic;
+            color: #6c757d;
+        }
+        
+        .evidence {
+            background: white;
+            padding: 10px;
+            border-radius: 4px;
+            border-left: 3px solid #007bff;
+            margin-top: 10px;
+        }
+        
+        .details {
+            margin-top: 10px;
+            font-size: 0.9rem;
+            color: #6c757d;
+        }
+        
+        .footer {
+            padding: 20px;
+            text-align: center;
+            background: #f8f9fa;
+            color: #6c757d;
+            font-size: 0.9rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>FOLIO Module Evaluation Report</h1>
+            <div class="metadata">
+                <div class="metadata-item">
+                    <div class="metadata-label">Module Name</div>
+                    <div>${result.moduleName}</div>
+                </div>
+                <div class="metadata-item">
+                    <div class="metadata-label">Language</div>
+                    <div>${result.language}</div>
+                </div>
+                <div class="metadata-item">
+                    <div class="metadata-label">Repository</div>
+                    <div><a href="${result.repositoryUrl}" target="_blank" style="color: #87ceeb;">${result.repositoryUrl}</a></div>
+                </div>
+                <div class="metadata-item">
+                    <div class="metadata-label">Evaluated At</div>
+                    <div>${result.evaluatedAt.toLocaleString()}</div>
+                </div>
+            </div>
+        </div>
+        
+        <div class="stats">
+            <div class="stat-card pass">
+                <div class="stat-number">${stats.pass}</div>
+                <div class="stat-label">Passed</div>
+            </div>
+            <div class="stat-card fail">
+                <div class="stat-number">${stats.fail}</div>
+                <div class="stat-label">Failed</div>
+            </div>
+            <div class="stat-card manual">
+                <div class="stat-number">${stats.manual}</div>
+                <div class="stat-label">Manual Review</div>
+            </div>
+            <div class="stat-card not_applicable">
+                <div class="stat-number">${stats.notApplicable}</div>
+                <div class="stat-label">Not Applicable</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-number">${stats.total}</div>
+                <div class="stat-label">Total Criteria</div>
+            </div>
+        </div>
+        
+        <div class="criteria-section">
+            <h2>Evaluation Results</h2>
+            ${this.generateCriteriaHtml(result)}
+        </div>
+        
+        <div class="footer">
+            Generated by FOLIO Module Evaluator | 
+            Report created on ${new Date().toLocaleString()}
+        </div>
+    </div>
+</body>
+</html>
+`;
+  }
+
+  escapeHtml(text: string): string {
+    const htmlEscapes: { [key: string]: string } = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;'
+    };
+    return text.replace(/[&<>"']/g, char => htmlEscapes[char]);
+  }
+
+  textToHtml(text: string): string {
+    return this.escapeHtml(text).replace(/\n/g, '<br>');
+  }
+
+  calculateStats(result: EvaluationResult): EvaluationReportStats {
+    const pass = result.criteria.filter(c => c.status === EvaluationStatus.PASS).length;
+    const fail = result.criteria.filter(c => c.status === EvaluationStatus.FAIL).length;
+    const manual = result.criteria.filter(c => c.status === EvaluationStatus.MANUAL).length;
+    const notApplicable = result.criteria.filter(c => c.status === EvaluationStatus.NOT_APPLICABLE).length;
+
+    return {
+      pass,
+      fail,
+      manual,
+      notApplicable,
+      total: result.criteria.length
+    };
+  }
+
+  private generateCriteriaHtml(result: EvaluationResult): string {
+    return result.criteria.map(criterion => `
+        <div class="criterion">
+            <div class="criterion-header ${criterion.status}">
+                <span class="status-badge ${criterion.status}">${criterion.status}</span>
+                <span>Criterion ${criterion.criterionId}</span>
+            </div>
+            <div class="criterion-content">
+                <div class="evidence">
+                    <strong>Evidence:</strong> ${this.escapeHtml(criterion.evidence)}
+                </div>
+                ${criterion.details ? `<div class="details">${this.textToHtml(criterion.details)}</div>` : ''}
+            </div>
+        </div>
+    `).join('');
+  }
+}


### PR DESCRIPTION
## Summary

The evaluator architecture now has a clearer internal shape without changing CLI behavior or public package exports. S003 license checking is isolated behind an injectable evaluator, acceptance criteria are catalog-backed for section execution and ordering, and report rendering is separated from filesystem persistence.

## What Changed

- Centralized acceptance criterion metadata so IDs, sections, ordering, language applicability, and default fallback wording live in one catalog.
- Added a catalog-backed section evaluator base that lets section evaluators declare real handlers and inherit default manual/not-implemented fallbacks.
- Wrapped third-party license evaluation in `ThirdPartyLicenseEvaluator` with injectable adapters for dependency extraction, README access, and ASF compliance checking.
- Split report HTML/JSON rendering from `ReportGenerator`, keeping file naming, output format options, and filesystem writes in the public generator.
- Simplified the devcontainer startup config by removing the extra git feature block.

## Verification

- `yarn test:unit`
- `yarn build`
- Devcontainer smoke evaluations:
  - `folio-org/mod-users`
  - `folio-org/mod-source-record-manager`
