### PR TITLE
fix: isolate npx environment for license checker

### DIFF
--- a/src/utils/parsers/npm-dependency-parser.ts
+++ b/src/utils/parsers/npm-dependency-parser.ts
@@ -60,6 +60,23 @@ const LICENSE_CHECK_TIMEOUT = 60000; // 60 seconds for license-checker
 const NPM_BUILD_FILES = ['package.json'];
 const FOLIO_NPM_REGISTRY_URL = 'https://repository.folio.org/repository/npm-folio';
 
+function createNpmToolEnv(repoPath: string): NodeJS.ProcessEnv {
+  const npmToolDir = path.join(repoPath, '.folio-eval-npm');
+  const npmPrefix = path.join(npmToolDir, 'prefix');
+  const npmCache = path.join(npmToolDir, 'cache');
+
+  fs.mkdirSync(path.join(npmPrefix, 'lib', 'node_modules'), { recursive: true });
+  fs.mkdirSync(path.join(npmPrefix, 'bin'), { recursive: true });
+  fs.mkdirSync(npmCache, { recursive: true });
+
+  return {
+    ...process.env,
+    NPM_CONFIG_PREFIX: npmPrefix,
+    NPM_CONFIG_CACHE: npmCache,
+    npm_config_prefix: npmPrefix,
+    npm_config_cache: npmCache
+  };
+}
 
 /**
  * Split an SPDX license expression that may contain multiple licenses
@@ -299,9 +316,10 @@ export async function getNpmDependencies(repoPath: string): Promise<DependencyEx
     // Use npx with pinned version to ensure consistency across environments
     getLogger().info('Running license-checker-rseidelsohn...');
     const { stdout } = await execAsync(
-      'npx license-checker-rseidelsohn@4.4.2 --json --production',
+      'npx --yes license-checker-rseidelsohn@4.4.2 --json --production',
       {
         cwd: validatedPath,
+        env: createNpmToolEnv(validatedPath),
         timeout: LICENSE_CHECK_TIMEOUT
       }
     );


### PR DESCRIPTION
## Summary

JavaScript evaluations no longer depend on the devcontainer or runner having a usable global npm prefix before `license-checker-rseidelsohn` runs. The npm tool invocation now gets an isolated prefix and cache inside the cloned repository, so `npx` can install and run the pinned checker instead of failing early and forcing package.json-only fallback results.

This keeps transitive dependency and license extraction available in environments where `NPM_CONFIG_PREFIX` points at an incomplete global directory.

## Verification

- `yarn test src/__tests__/npm-dependency-parser.test.ts --runInBand`
- `yarn build`
- `docker exec <CONTAINER_ID> zsh -lc 'cd /workspace && node dist/cli.js evaluate https://github.com/folio-org/ui-users --output ./reports/ui-users-devcontainer-license-fixed --json-only'`
