### PR TITLE
test: add golden JSON regression fixture

### DIFF
--- a/src/__tests__/fixtures/golden-reports/mod-rtac-cache-v1.1.1.json
+++ b/src/__tests__/fixtures/golden-reports/mod-rtac-cache-v1.1.1.json
@@ -1,0 +1,194 @@
+{
+  "repositoryUrl": "https://github.com/folio-org/mod-rtac-cache",
+  "moduleName": "mod-rtac-cache",
+  "language": "Java",
+  "evaluatedAt": "<<normalized-evaluatedAt>>",
+  "criteria": [
+    {
+      "criterionId": "A001",
+      "status": "manual",
+      "evidence": "Product Council approval verification requires manual review",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "S001",
+      "status": "pass",
+      "evidence": "Apache 2.0 license found in LICENSE",
+      "details": "License file: LICENSE"
+    },
+    {
+      "criterionId": "S002",
+      "status": "manual",
+      "evidence": "Module descriptor validation - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "S003",
+      "status": "manual",
+      "evidence": "Found 251 dependencies. Licenses: com.dynatrace.hash4j:hash4j:0.22.0 (The Apache Software License, Version 2.0); com.fasterxml:classmate:1.7.3 (Apache License 2.0); com.fasterxml.jackson.core:jackson-annotations:2.20 (The Apache Software License, Version 2.0); com.fasterxml.jackson.core:jackson-core:2.20.2 (The Apache Software License, Version 2.0); com.fasterxml.jackson.core:jackson-databind:2.20.2 (The Apache Software License, Version 2.0); com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.20.2 (The Apache Software License, Version 2.0); com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.20.2 (The Apache Software License, Version 2.0); com.fasterxml.jackson.datatype:jackson-datatype-guava:2.20.2 (The Apache Software License, Version 2.0); com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.20.2 (The Apache Software License, Version 2.0); com.fasterxml.jackson.datatype:jackson-datatype-joda:2.20.2 (The Apache Software License, Version 2.0); com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.20.2 (The Apache Software License, Version 2.0); com.github.ben-manes.caffeine:caffeine:3.2.3 (Apache License 2.0); com.github.curious-odd-man:rgxgen:1.4 (The Apache Software License, Version 2.0); com.github.docker-java:docker-java-api:3.7.0 (The Apache Software License, Version 2.0); com.github.docker-java:docker-java-transport:3.7.0 (The Apache Software License, Version 2.0); com.github.docker-java:docker-java-transport-zerodep:3.7.0 (The Apache Software License, Version 2.0); com.github.jknack:handlebars:4.3.1 (The Apache Software License, Version 2.0); com.github.jknack:handlebars-jackson2:4.3.1 (The Apache Software License, Version 2.0); com.github.joschi.jackson:jackson-datatype-threetenbp:2.18.2 (The Apache Software License, Version 2.0); com.github.luben:zstd-jni:1.5.6-10 (BSD-2-Clause); com.github.mifmif:generex:1.0.2 (The Apache Software License, Version 2.0); com.google.code.findbugs:jsr305:3.0.2 (The Apache Software License, Version 2.0); com.google.errorprone:error_prone_annotations:2.21.1 (Apache-2.0); com.google.guava:failureaccess:1.0.1 (The Apache Software License, Version 2.0); com.google.guava:guava:32.1.3-jre (Apache License 2.0); com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (The Apache Software License, Version 2.0); com.google.j2objc:j2objc-annotations:2.8 (Apache License 2.0); com.google.re2j:re2j:1.8 (BSD-3-Clause); com.googlecode.libphonenumber:libphonenumber:8.11.1 (The Apache Software License, Version 2.0); com.jayway.jsonpath:json-path:2.10.0 (The Apache Software License, Version 2.0); com.opencsv:opencsv:5.12.0 (Apache-2.0); com.sun.istack:istack-commons-runtime:4.1.2 (EPL-1.0); com.typesafe.scala-logging:scala-logging_2.13:3.9.5 (Apache-2.0); com.vaadin.external.google:android-json:0.0.20131108.vaadin1 (Apache License 2.0); com.yammer.metrics:metrics-core:2.2.0 (Apache License 2.0); com.zaxxer:HikariCP:7.0.2 (The Apache Software License, Version 2.0); commons-beanutils:commons-beanutils:1.9.4 (Apache License 2.0); commons-cli:commons-cli:1.10.0 (Apache-2.0); commons-codec:commons-codec:1.19.0 (Apache-2.0); commons-collections:commons-collections:3.2.2 (Apache License 2.0); commons-digester:commons-digester:2.1 (The Apache Software License, Version 2.0); commons-io:commons-io:2.20.0 (Apache-2.0); commons-logging:commons-logging:1.3.5 (Apache-2.0); commons-validator:commons-validator:1.9.0 (Apache-2.0); dk.brics.automaton:automaton:1.11-8 (BSD-3-Clause); io.micrometer:micrometer-commons:1.16.3 (The Apache Software License, Version 2.0); io.micrometer:micrometer-core:1.16.3 (The Apache Software License, Version 2.0); io.micrometer:micrometer-jakarta9:1.16.3 (The Apache Software License, Version 2.0); io.micrometer:micrometer-observation:1.16.3 (The Apache Software License, Version 2.0); io.netty:netty-buffer:4.2.10.Final (Apache License 2.0); io.netty:netty-codec-base:4.2.10.Final (Apache License 2.0); io.netty:netty-codec-compression:4.2.10.Final (Apache License 2.0); io.netty:netty-codec-http:4.2.10.Final (Apache License 2.0); io.netty:netty-common:4.2.10.Final (Apache License 2.0); io.netty:netty-handler:4.2.10.Final (Apache License 2.0); io.netty:netty-resolver:4.2.10.Final (Apache License 2.0); io.netty:netty-transport:4.2.10.Final (Apache License 2.0); io.netty:netty-transport-native-unix-common:4.2.10.Final (Apache License 2.0); io.swagger:swagger-annotations:1.6.16 (Apache License 2.0); io.swagger:swagger-compat-spec-parser:1.0.75 (Apache License 2.0); io.swagger:swagger-core:1.6.16 (Apache License 2.0); io.swagger:swagger-models:1.6.16 (Apache License 2.0); io.swagger:swagger-parser:1.0.75 (Apache License 2.0); io.swagger:swagger-parser-safe-url-resolver:1.0.75 (Apache License 2.0); io.swagger.core.v3:swagger-annotations:2.2.46 (Apache License 2.0); io.swagger.core.v3:swagger-core:2.2.37 (Apache License 2.0); io.swagger.core.v3:swagger-models:2.2.37 (Apache License 2.0); io.swagger.parser.v3:swagger-parser:2.1.38 (Apache License 2.0); io.swagger.parser.v3:swagger-parser-core:2.1.38 (Apache License 2.0); io.swagger.parser.v3:swagger-parser-safe-url-resolver:2.1.38 (Apache License 2.0); io.swagger.parser.v3:swagger-parser-v2-converter:2.1.38 (Apache License 2.0); io.swagger.parser.v3:swagger-parser-v3:2.1.38 (Apache License 2.0); jakarta.activation:jakarta.activation-api:2.1.4 (EPL-1.0); jakarta.inject:jakarta.inject-api:2.0.1 (The Apache Software License, Version 2.0); jakarta.validation:jakarta.validation-api:3.1.1 (Apache License 2.0); jakarta.xml.bind:jakarta.xml.bind-api:4.0.4 (EPL-1.0); javax.inject:javax.inject:1 (The Apache Software License, Version 2.0); joda-time:joda-time:2.12.7 (Apache License 2.0); net.bytebuddy:byte-buddy-agent:1.17.8 (Apache License 2.0); net.minidev:accessors-smart:2.6.0 (The Apache Software License, Version 2.0); net.minidev:json-smart:2.6.0 (The Apache Software License, Version 2.0); net.sf.jopt-simple:jopt-simple:5.0.4 (MIT License); net.sourceforge.argparse4j:argparse4j:0.7.0 (MIT); org.antlr:antlr4-runtime:4.13.2 (BSD-3-Clause); org.apache.commons:commons-collections4:4.5.0 (Apache-2.0); org.apache.commons:commons-compress:1.28.0 (Apache-2.0); org.apache.commons:commons-lang3:3.19.0 (Apache-2.0); org.apache.commons:commons-text:1.14.0 (Apache-2.0); org.apache.httpcomponents:httpclient:4.5.14 (Apache License 2.0); org.apache.httpcomponents:httpcore:4.4.16 (Apache License 2.0); org.apache.kafka:kafka-clients:4.1.1 (The Apache Software License, Version 2.0); org.apache.kafka:kafka-coordinator-common:4.1.1 (The Apache Software License, Version 2.0); org.apache.kafka:kafka-group-coordinator:4.1.1 (The Apache Software License, Version 2.0); org.apache.kafka:kafka-group-coordinator-api:4.1.1 (The Apache Software License, Version 2.0); org.apache.kafka:kafka-metadata:4.1.1 (The Apache Software License, Version 2.0); org.apache.kafka:kafka-raft:4.1.1 (The Apache Software License, Version 2.0); org.apache.kafka:kafka-server:4.1.1 (The Apache Software License, Version 2.0); org.apache.kafka:kafka-server-common:4.1.1 (The Apache Software License, Version 2.0); org.apache.kafka:kafka-share-coordinator:4.1.1 (The Apache Software License, Version 2.0); org.apache.kafka:kafka-storage:4.1.1 (The Apache Software License, Version 2.0); org.apache.kafka:kafka-storage-api:4.1.1 (The Apache Software License, Version 2.0); org.apache.kafka:kafka-streams:4.1.1 (The Apache Software License, Version 2.0); org.apache.kafka:kafka-streams-test-utils:4.1.1 (The Apache Software License, Version 2.0); org.apache.kafka:kafka-test-common-internal-api:4.1.1 (The Apache Software License, Version 2.0); org.apache.kafka:kafka-test-common-runtime:4.1.1 (The Apache Software License, Version 2.0); org.apache.kafka:kafka-tools-api:4.1.1 (The Apache Software License, Version 2.0); org.apache.kafka:kafka-transaction-coordinator:4.1.1 (The Apache Software License, Version 2.0); org.apache.kafka:kafka_2.13:4.1.1 (The Apache Software License, Version 2.0); org.apache.logging.log4j:log4j-api:2.25.3 (Apache-2.0); org.apache.logging.log4j:log4j-core:2.25.3 (Apache-2.0); org.apache.logging.log4j:log4j-jul:2.25.3 (Apache-2.0); org.apache.logging.log4j:log4j-slf4j2-impl:2.25.3 (Apache-2.0); org.apache.maven.plugin-tools:maven-plugin-annotations:3.9.0 (Apache-2.0); org.apache.maven.resolver:maven-resolver-api:1.9.18 (Apache-2.0); org.apache.maven.resolver:maven-resolver-util:1.9.18 (Apache-2.0); org.apache.tomcat.embed:tomcat-embed-core:11.0.18 (Apache License 2.0); org.apache.tomcat.embed:tomcat-embed-el:11.0.18 (Apache License 2.0); org.apache.tomcat.embed:tomcat-embed-websocket:11.0.18 (Apache License 2.0); org.apiguardian:apiguardian-api:1.1.2 (The Apache Software License, Version 2.0); org.aspectj:aspectjweaver:1.9.25.1 (Eclipse Public License); org.assertj:assertj-core:3.27.7 (Apache-2.0); org.awaitility:awaitility:4.3.0 (Apache-2.0); org.bitbucket.b_c:jose4j:0.9.6 (The Apache Software License, Version 2.0); org.checkerframework:checker-qual:3.52.0 (MIT License); org.codehaus.plexus:plexus-build-api:1.2.0 (Apache License 2.0); org.codehaus.plexus:plexus-utils:4.0.0 (Apache License 2.0); org.commonmark:commonmark:0.21.0 (BSD-2-Clause); org.eclipse.angus:angus-activation:2.0.3 (EPL-1.0); org.eclipse.sisu:org.eclipse.sisu.plexus:0.9.0.M2 (Eclipse Public License 1.0); org.folio:folio-service-tools-spring-dev:6.0.0 (Apache License 2.0); org.folio:folio-spring-base:10.0.0 (Apache License 2.0); org.folio:folio-spring-common:10.0.0 (Apache License 2.0); org.folio:folio-spring-system-user:10.0.0 (Apache License 2.0); org.folio:util:35.4.2 (Apache-2.0); org.glassfish.jaxb:jaxb-core:4.0.6 (EPL-1.0); org.glassfish.jaxb:jaxb-runtime:4.0.6 (EPL-1.0); org.glassfish.jaxb:txw2:4.0.6 (EPL-1.0); org.hamcrest:hamcrest:3.0 (BSD-3-Clause); org.hibernate.models:hibernate-models:1.0.1 (Apache License 2.0); org.hibernate.orm:hibernate-core:7.2.4.Final (Apache License 2.0); org.hibernate.validator:hibernate-validator:9.0.1.Final (Apache License 2.0); org.jboss.logging:jboss-logging:3.6.2.Final (Apache License 2.0); org.jetbrains:annotations:17.0.0 (The Apache Software License, Version 2.0); org.jspecify:jspecify:1.0.0 (The Apache Software License, Version 2.0); org.junit.jupiter:junit-jupiter-api:6.0.3 (EPL-2.0); org.junit.jupiter:junit-jupiter-engine:6.0.3 (EPL-2.0); org.junit.jupiter:junit-jupiter-params:6.0.3 (EPL-2.0); org.junit.platform:junit-platform-commons:6.0.3 (EPL-2.0); org.junit.platform:junit-platform-engine:6.0.3 (EPL-2.0); org.junit.platform:junit-platform-launcher:6.0.3 (EPL-2.0); org.latencyutils:LatencyUtils:2.0.3 (Public Domain); org.liquibase:liquibase-core:5.0.1 (FSL-1.1-ALv2); org.lz4:lz4-java:1.8.0 (The Apache Software License, Version 2.0); org.mapstruct:mapstruct:1.6.3 (The Apache Software License, Version 2.0); org.mockito:mockito-core:5.20.0 (MIT); org.mockito:mockito-junit-jupiter:5.20.0 (MIT); org.mozilla:rhino:1.9.1 (Mozilla Public License 2.0); org.objenesis:objenesis:3.3 (Apache License 2.0); org.openapitools:jackson-databind-nullable:0.2.10 (Apache License 2.0); org.openapitools:openapi-generator-core:7.21.0 (Apache License 2.0); org.opentest4j:opentest4j:1.3.0 (The Apache Software License, Version 2.0); org.ow2.asm:asm:9.7.1 (BSD-3-Clause); org.pcollections:pcollections:4.0.2 (MIT License); org.postgresql:postgresql:42.7.10 (BSD-2-Clause); org.projectlombok:lombok:1.18.42 (MIT License); org.rnorth.duct-tape:duct-tape:1.0.8 (MIT); org.scala-lang:scala-library:2.13.16 (Apache-2.0); org.scala-lang:scala-reflect:2.13.16 (Apache-2.0); org.skyscreamer:jsonassert:1.5.3 (The Apache Software License, Version 2.0); org.slf4j:jul-to-slf4j:2.0.17 (MIT); org.slf4j:slf4j-api:2.0.17 (MIT); org.slf4j:slf4j-ext:2.0.17 (MIT); org.sonatype.plexus:plexus-build-api:0.0.7 (Apache-2.0); org.springframework:spring-aop:7.0.5 (Apache License 2.0); org.springframework:spring-aspects:7.0.5 (Apache License 2.0); org.springframework:spring-beans:7.0.5 (Apache License 2.0); org.springframework:spring-context:7.0.5 (Apache License 2.0); org.springframework:spring-context-support:7.0.5 (Apache License 2.0); org.springframework:spring-core:7.0.5 (Apache License 2.0); org.springframework:spring-jdbc:7.0.5 (Apache License 2.0); org.springframework:spring-messaging:7.0.5 (Apache License 2.0); org.springframework:spring-orm:7.0.5 (Apache License 2.0); org.springframework:spring-test:7.0.5 (Apache License 2.0); org.springframework:spring-tx:7.0.5 (Apache License 2.0); org.springframework:spring-web:7.0.5 (Apache License 2.0); org.springframework:spring-webmvc:7.0.5 (Apache License 2.0); org.springframework.boot:spring-boot:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-actuator:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-actuator-autoconfigure:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-autoconfigure:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-cache:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-configuration-metadata:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-data-commons:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-data-jpa:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-health:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-hibernate:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-http-converter:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-jackson:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-jdbc:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-jpa:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-kafka:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-liquibase:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-micrometer-metrics:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-micrometer-observation:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-persistence:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-properties-migrator:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-servlet:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-sql:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-starter:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-starter-actuator:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-starter-cache:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-starter-data-jpa:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-starter-jackson:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-starter-jdbc:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-starter-kafka:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-starter-kafka-test:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-starter-liquibase:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-starter-log4j2:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-starter-logging:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-starter-micrometer-metrics:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-starter-test:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-starter-tomcat:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-starter-tomcat-runtime:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-starter-validation:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-starter-web:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-starter-webmvc:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-test:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-test-autoconfigure:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-tomcat:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-transaction:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-validation:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-web-server:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-webmvc:4.0.3 (Apache License 2.0); org.springframework.boot:spring-boot-webmvc-test:4.0.3 (Apache License 2.0); org.springframework.data:spring-data-commons:4.0.3 (Apache License 2.0); org.springframework.data:spring-data-jpa:4.0.3 (Apache License 2.0); org.springframework.kafka:spring-kafka:4.0.3 (Apache License 2.0); org.springframework.kafka:spring-kafka-test:4.0.3 (Apache License 2.0); org.testcontainers:database-commons:1.21.4 (MIT); org.testcontainers:jdbc:1.21.4 (MIT); org.testcontainers:junit-jupiter:1.21.4 (MIT); org.testcontainers:kafka:1.21.4 (MIT); org.testcontainers:postgresql:1.21.4 (MIT); org.testcontainers:testcontainers:2.0.3 (MIT); org.threeten:threetenbp:1.7.0 (BSD-3-Clause); org.wiremock:wiremock-standalone:3.13.2 (The Apache Software License, Version 2.0); org.xerial.snappy:snappy-java:1.1.10.7 (Apache-2.0); org.xmlunit:xmlunit-core:2.10.4 (The Apache Software License, Version 2.0); org.yaml:snakeyaml:2.5 (Apache License 2.0); tools.jackson.core:jackson-core:3.0.4 (The Apache Software License, Version 2.0); tools.jackson.core:jackson-databind:3.0.4 (The Apache Software License, Version 2.0)",
+      "details": "Third-party license compliance issues require manual review. Please verify these dependencies comply with ASF 3rd Party License Policy:\n• org.aspectj:aspectjweaver:1.9.25.1 - Unknown license 'Eclipse Public License' - requires manual review\n• org.liquibase:liquibase-core:5.0.1 - Unknown license 'FSL-1.1-ALv2' - requires manual review"
+    },
+    {
+      "criterionId": "S004",
+      "status": "manual",
+      "evidence": "README file evaluation - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "S005",
+      "status": "manual",
+      "evidence": "Version control and branching strategy - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "S006",
+      "status": "manual",
+      "evidence": "Code quality and static analysis - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "S007",
+      "status": "manual",
+      "evidence": "Testing requirements - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "S008",
+      "status": "manual",
+      "evidence": "Documentation requirements - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "S009",
+      "status": "manual",
+      "evidence": "Security requirements - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "S010",
+      "status": "manual",
+      "evidence": "Performance requirements - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "S011",
+      "status": "manual",
+      "evidence": "Accessibility requirements - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "S012",
+      "status": "manual",
+      "evidence": "Internationalization requirements - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "S013",
+      "status": "manual",
+      "evidence": "Configuration management - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "S014",
+      "status": "manual",
+      "evidence": "Monitoring and logging - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "B001",
+      "status": "manual",
+      "evidence": "API design and RESTful principles - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "B002",
+      "status": "manual",
+      "evidence": "Database design and schema management - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "B003",
+      "status": "manual",
+      "evidence": "Error handling and validation - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "B004",
+      "status": "manual",
+      "evidence": "Authentication and authorization - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "B005",
+      "status": "manual",
+      "evidence": "Data persistence and transactions - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "B006",
+      "status": "manual",
+      "evidence": "Caching strategy - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "B007",
+      "status": "manual",
+      "evidence": "Event-driven architecture - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "B008",
+      "status": "manual",
+      "evidence": "Microservice architecture compliance - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "B009",
+      "status": "manual",
+      "evidence": "Health checks and monitoring endpoints - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "B010",
+      "status": "manual",
+      "evidence": "Scalability and load handling - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "B011",
+      "status": "manual",
+      "evidence": "Data migration and backward compatibility - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "B012",
+      "status": "manual",
+      "evidence": "Environment configuration - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "B013",
+      "status": "manual",
+      "evidence": "Dependency injection and IoC - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "B014",
+      "status": "manual",
+      "evidence": "API versioning strategy - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "B015",
+      "status": "manual",
+      "evidence": "Resource management - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    },
+    {
+      "criterionId": "B016",
+      "status": "manual",
+      "evidence": "Integration testing - evaluation logic not yet implemented",
+      "details": "This criterion requires manual evaluation by a human reviewer"
+    }
+  ]
+}

--- a/src/__tests__/integration/cli.integration.test.ts
+++ b/src/__tests__/integration/cli.integration.test.ts
@@ -3,7 +3,17 @@ import * as fs from 'fs-extra';
 import * as os from 'os';
 import { ModuleEvaluator } from '../../module-evaluator';
 import { ReportGenerator } from '../../utils/report-generator';
-import { EvaluationConfig, ReportOptions } from '../../types';
+import { EvaluationConfig, EvaluationResult, ReportOptions } from '../../types';
+
+const GOLDEN_EVALUATED_AT = '<<normalized-evaluatedAt>>';
+type NormalizedEvaluationReport = Omit<EvaluationResult, 'evaluatedAt'> & { evaluatedAt: string };
+
+function normalizeEvaluationReport(report: EvaluationResult): NormalizedEvaluationReport {
+  return {
+    ...report,
+    evaluatedAt: GOLDEN_EVALUATED_AT,
+  };
+}
 
 describe('CLI Integration Tests', () => {
   const testOutputDir = path.join(os.tmpdir(), 'folio-eval-integration-tests', Date.now().toString());
@@ -215,6 +225,43 @@ describe('CLI Integration Tests', () => {
       // Verify HTML file exists
       const htmlExists = await fs.pathExists(reportPaths.htmlPath!);
       expect(htmlExists).toBe(true);
+    });
+  });
+
+  describe('Golden Report Regression', () => {
+    test('should match normalized JSON report for mod-rtac-cache v1.1.1', async () => {
+      const repoUrl = 'https://github.com/folio-org/mod-rtac-cache';
+      const config: EvaluationConfig = {
+        outputDir: testOutputDir,
+        skipCleanup: false,
+        branch: 'v1.1.1',
+      };
+
+      const evaluator = new ModuleEvaluator(config);
+      const result = await evaluator.evaluateModule(repoUrl);
+
+      const reportGenerator = new ReportGenerator(testOutputDir);
+      const reportPaths = await reportGenerator.generateReports(result, {
+        outputHtml: false,
+        outputJson: true,
+        outputDir: testOutputDir,
+      });
+
+      expect(reportPaths.htmlPath).toBeUndefined();
+      expect(reportPaths.jsonPath).toBeDefined();
+
+      const jsonContent = await fs.readFile(reportPaths.jsonPath!, 'utf-8');
+      const actualReport = normalizeEvaluationReport(JSON.parse(jsonContent));
+      const goldenPath = path.join(
+        __dirname,
+        '..',
+        'fixtures',
+        'golden-reports',
+        'mod-rtac-cache-v1.1.1.json'
+      );
+      const expectedReport = JSON.parse(await fs.readFile(goldenPath, 'utf-8'));
+
+      expect(actualReport).toEqual(expectedReport);
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a golden JSON regression test for evaluating `folio-org/mod-rtac-cache` at immutable tag `v1.1.1`.

The test runs the evaluator and JSON report generator, normalizes the volatile `evaluatedAt` field, and compares the generated report against a committed fixture.

## Changes

- Adds a golden fixture for `mod-rtac-cache@v1.1.1`
- Adds an integration test that evaluates the real repository at the pinned tag
- Generates JSON-only report output for comparison
- Normalizes `evaluatedAt` so timestamp changes do not cause failures
- Keeps report content, criterion order, evidence, statuses, metadata, language, and repository URL pinned by the fixture

## Verification

- `yarn test:integration`
- `yarn build`