### PR TITLE
fix(devcontainer): support arm64 and x86 Java paths

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,6 +28,7 @@ RUN wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt
   echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list && \
   apt-get update && apt-get install -y --no-install-recommends \
   temurin-21-jdk \
+  && ln -sfn "/usr/lib/jvm/temurin-21-jdk-$(dpkg --print-architecture)" /usr/lib/jvm/temurin-21-jdk \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install Maven
@@ -45,7 +46,7 @@ RUN wget https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.
   rm gradle-${GRADLE_VERSION}-bin.zip
 
 # Set Java environment variables
-ENV JAVA_HOME=/usr/lib/jvm/temurin-21-jdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/temurin-21-jdk
 ENV MAVEN_HOME=/opt/maven
 ENV GRADLE_HOME=/opt/gradle
 ENV PATH=$PATH:$MAVEN_HOME/bin:$GRADLE_HOME/bin

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,7 +45,7 @@
         "java.configuration.runtimes": [
           {
             "name": "JavaSE-21",
-            "path": "/usr/lib/jvm/temurin-21-jdk-amd64",
+            "path": "/usr/lib/jvm/temurin-21-jdk",
             "default": true
           }
         ]
@@ -61,7 +61,7 @@
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",
     "POWERLEVEL9K_DISABLE_GITSTATUS": "true",
-    "JAVA_HOME": "/usr/lib/jvm/temurin-21-jdk-amd64",
+    "JAVA_HOME": "/usr/lib/jvm/temurin-21-jdk",
     "MAVEN_HOME": "/opt/maven",
     "GRADLE_HOME": "/opt/gradle"
   },


### PR DESCRIPTION
## Summary
The devcontainer now resolves Java through an architecture-neutral path, so Apple Silicon and x86 hosts can use the same `JAVA_HOME` and VS Code Java runtime configuration. The Dockerfile creates `/usr/lib/jvm/temurin-21-jdk` as a symlink to the architecture-specific Temurin install, which avoids hardcoding `amd64` while preserving Maven and Gradle behavior.

## Verification
Recreated the devcontainer with `devcontainer up --remove-existing-container --build-no-cache` and verified inside the fresh container that `JAVA_HOME=/usr/lib/jvm/temurin-21-jdk` resolves to `/usr/lib/jvm/temurin-21-jdk-arm64` on this host, with Maven using Java 21 successfully.
