### PR TITLE
fix(ci): run hosted actions on Node 24

### DIFF
--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -70,13 +70,13 @@ jobs:
 
     steps:
       - name: Checkout tc-module-eval
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: folio-org/tc-module-eval
           ref: ${{ inputs.evaluator_ref }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ inputs.node_version }}
           architecture: "x64"
@@ -89,7 +89,7 @@ jobs:
           echo "week=$(date +%Y-W%V)" >> $GITHUB_OUTPUT
 
       - name: Cache npm dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-folio-deps-${{ steps.cache-keys.outputs.week }}
@@ -97,13 +97,13 @@ jobs:
             ${{ runner.os }}-npm-folio-deps-
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ inputs.java_version }}
           distribution: "temurin"
 
       - name: Cache Maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-folio-deps-${{ steps.cache-keys.outputs.week }}
@@ -111,7 +111,7 @@ jobs:
             ${{ runner.os }}-maven-folio-deps-
 
       - name: Cache Gradle dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -277,7 +277,7 @@ jobs:
           sync
 
       - name: Upload evaluation reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: ${{ steps.artifact-name.outputs.name }}


### PR DESCRIPTION
## Summary
GitHub Actions no longer emits the Node 20 deprecation warning for the manual module-evaluation workflow. The workflow now uses first-party action versions whose runtimes target Node 24 while leaving the evaluator's Node.js input unchanged.

## Validation
Ran `Evaluate Remote Repository (Manual)` on this branch for `folio-org/mod-users` at `ref=master`: https://github.com/folio-org/tc-module-eval/actions/runs/28182422538
